### PR TITLE
Fix expected scalar type Half but found Float.

### DIFF
--- a/dreambooth/train_dreambooth.py
+++ b/dreambooth/train_dreambooth.py
@@ -691,7 +691,7 @@ def main(args):
     # as these models are only used for inference, keeping weights in full precision is not required.
     vae.to(accelerator.device, dtype=weight_dtype)
     if not args.train_text_encoder:
-        text_encoder.to(accelerator.device, dtype=weight_dtype)
+        text_encoder.to(accelerator.device)
 
     if not args.not_cache_latents:
         latents_cache = []


### PR DESCRIPTION
`RuntimeError: expected scalar type Half but found Float` would occur when no no_cache_latents + no train_text_encoder + fp16.
This fixes #37 
I can confirm it works correctly with the following conditions:

- train_text_encoder, because this line will not be evaluated anyway
- no train_text_encoder + no no_cache_latents + fp16
- no train_text_encoder + no_cache_latents + fp16

I only have 12GB VRAM and cannot afford to test whether it breaks no mixed precision. I truely don't think so because it is already fp32.
