### PR TITLE
Warn user before overwriting torch/torchvision installation

### DIFF
--- a/install.py
+++ b/install.py
@@ -3,6 +3,7 @@ import subprocess
 import sys
 import importlib
 import git
+import os
 
 from launch import run_pip, run
 import os
@@ -11,7 +12,11 @@ name = "Dreambooth"
 req_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), "requirements.txt")
 print(f"loading Dreambooth reqs from {req_file}")
 run(f'"{sys.executable}" -m pip install -r "{req_file}"', f"Checking {name} requirements.", f"Couldn't install {name} requirements.")
-torch_cmd="pip install torch==1.12.1+cu116 torchvision==0.13.1+cu116 --extra-index-url " \
+
+torch_cmd = os.environ.get('TORCH_COMMAND', None)
+if torch_cmd is None:
+    print("WARNING: overwriting existing torch/torchvision installation!")
+    torch_cmd = "pip install torch==1.12.1+cu116 torchvision==0.13.1+cu116 --extra-index-url " \
           "https://download.pytorch.org/whl/cu116 "
 run(f'"{sys.executable}" -m {torch_cmd}', "Checking torch and torchvision versions", "Couldn't install torch")
 


### PR DESCRIPTION
Thank you for developing this great project!

When I installed this extension, the torch command in `install.py` overwrote my existing `torch==1.13` && `torchvision==1.14` packages. This predictably broke `xformers` and caused my webui installation to break :)

You added the `TORCH_COMMAND` env var to allow for users to define their own torch/torchvision package versions. I have added code in `install.py` to respect the `TORCH_COMMAND` env var.

---

I don't actually know what the intended behavior here is. Is torch/torchvision supposed to be overwritten? Should the user be warned if their torch version is below (not equal?) 1.12+cu116? 