### PR TITLE
Switch from launch to subprocess in install.py

### DIFF
--- a/install.py
+++ b/install.py
@@ -2,10 +2,10 @@ import filecmp
 import os
 import shutil
 import sys
+import subprocess
 
 import git
 
-from launch import run
 from modules.paths import script_path
 
 dreambooth_skip_install = os.environ.get('DREAMBOOTH_SKIP_INSTALL', False)
@@ -13,8 +13,8 @@ if not dreambooth_skip_install:
     name = "Dreambooth"
     req_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), "requirements.txt")
     print(f"Installing requirements for Dreambooth")
-    run(f'"{sys.executable}" -m pip install -r "{req_file}"', f"Checking {name} requirements.",
-        f"Couldn't install {name} requirements.")
+    subprocess.run([{sys.executable}, "-m", "pip", "install", "-r", {req_file}],
+        stdout=f"Checking {name} requirements.", stderr=f"Couldn't install {name} requirements.")
 
     # I think we only need to bump torch version to cu116 on Windows, as we're using prebuilt B&B Binaries...
     if os.name == "nt":
@@ -23,7 +23,8 @@ if not dreambooth_skip_install:
             print("Checking/upgrading existing torch/torchvision installation")
             torch_cmd = "pip install torch==1.12.1+cu116 torchvision==0.13.1+cu116 --extra-index-url " \
                         "https://download.pytorch.org/whl/cu116 "
-        run(f'"{sys.executable}" -m {torch_cmd}', "Checking torch and torchvision versions", "Couldn't install torch")
+        subprocess.run([{sys.executable}, "-m", {torch_cmd}],
+            stdout="Checking torch and torchvision versions", stderr="Couldn't install torch")
 
 try:
     base_dir = os.path.dirname(os.path.realpath(__file__))


### PR DESCRIPTION
No longer use launch because the officially recommended way to invoke subprocesses is through subprocess: https://docs.python.org/3/library/subprocess.html