### PR TITLE
Disabled safety checker

### DIFF
--- a/dreambooth/train_dreambooth.py
+++ b/dreambooth/train_dreambooth.py
@@ -461,6 +461,7 @@ def main(args: DreamboothConfig, memory_record, use_subdir) -> tuple[DreamboothC
                         ),
                         torch_dtype=torch_dtype,
                         requires_safety_checker=False,
+                        safety_checker=None,
                         revision=args.revision
                     )
 


### PR DESCRIPTION
Assuming you are wanting to allow NSFW images, the arguments for diffusers pipeline requires an additional argument

Based on this commit history in [diffusers repo](https://github.com/huggingface/diffusers/pull/1395/commits/81c85ea125a90b1f9d81241a41f5734f82bf681a#diff-854f0ccc47bab7d5aa712cee3546258dd745d5dc4a35915eae7afb71f05467fbR173)