### PR TITLE
Add missed outputs parameter

### DIFF
--- a/scripts/main.py
+++ b/scripts/main.py
@@ -313,7 +313,8 @@ def on_ui_tabs():
                 c3_save_sample_negative_prompt,
                 c3_save_sample_prompt,
                 c3_save_sample_template
-            ]
+            ],
+            outputs=[]
         )
 
         db_load_params.click(


### PR DESCRIPTION
Fix TypeError: click() missing 1 required positional argument 'outputs'. This should be empty or None, because save_config returns None