### PR TITLE
Fixed OOM when using lora on a 8GB GPU while saving model weights

### DIFF
--- a/dreambooth/train_dreambooth.py
+++ b/dreambooth/train_dreambooth.py
@@ -941,8 +941,9 @@ def main(args: DreamboothConfig, memory_record, use_subdir, lora_model=None, lor
             del s_pipeline
             del scheduler
             del text_enc_model
-            if g_cuda:
-                del g_cuda
+            if not save_img:
+                if g_cuda:
+                    del g_cuda
             #cleanup()
 
     # Only show the progress bar once on each machine.

--- a/dreambooth/train_dreambooth.py
+++ b/dreambooth/train_dreambooth.py
@@ -889,7 +889,7 @@ def main(args: DreamboothConfig, memory_record, use_subdir, lora_model=None, lor
                                 args.pretrained_model_name_or_path,
                                 subfolder="unet",
                                 revision=args.revision,
-                                torch_dtype=torch.float32
+                                torch_dtype=torch.float16
                             ).to(accelerator.device)
                         else:
                             out_file = None


### PR DESCRIPTION
Using float32 while saving the model weights causes a spike in vram usage while saving. This fixes that. When not using lora, weights are already saved with float16 by default.