### PR TITLE
fixes #502 training steps per image need to be an int, not a float

### DIFF
--- a/scripts/main.py
+++ b/scripts/main.py
@@ -89,8 +89,8 @@ def on_ui_tabs():
                     with gr.Accordion(open=True, label="Settings"):
                         with gr.Column():
                             gr.HTML(value="Intervals")
-                            db_num_train_epochs = gr.Number(label="Training Steps Per Image (Epochs)", precision=100,
-                                                            value=1)
+                            db_num_train_epochs = gr.Number(label="Training Steps Per Image (Epochs)", precision=0,
+                                                            value=100)
                             db_max_train_steps = gr.Number(label='Max Training Steps', value=0, precision=0)
                             db_epoch_pause_frequency = gr.Number(label='Pause After N Epochs', value=0)
                             db_epoch_pause_time = gr.Number(label='Amount of time to pause between Epochs, in Seconds',


### PR DESCRIPTION
#502 the precision and value had been swapped in the number of training steps (Epoch) field, so was giving a float value of 100 places when it actually needed an int.  Since default value of 100 is typical assume that the intent was value of 100 and precision of 0 (has 1 but again would fail since we need int number of training steps)

