### PR TITLE
Fix race condition between use_ema and use_lora as they need to be mutually exclusive

### DIFF
--- a/dreambooth/db_config.py
+++ b/dreambooth/db_config.py
@@ -181,8 +181,8 @@ class DreamboothConfig:
         self.use_8bit_adam = use_8bit_adam
         self.use_concepts = use_concepts
         self.use_cpu = use_cpu
-        self.use_ema = use_ema
-        self.use_lora = use_lora
+        self.use_ema = False if use_ema is None else use_ema
+        self.use_lora = False if use_lora is None else use_lora
         if scheduler is not None:
             self.scheduler = scheduler
 

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -454,14 +454,20 @@ def on_ui_tabs():
             outputs=[hub_row],
         )
 
+        def disable_ema(x):
+            db_use_ema.interactive = not x
+
+        def disable_lora(x):
+            db_use_lora.interactive = not x            
+
         db_use_lora.change(
-            fn=lambda x: False if x else db_use_lora,
+            fn=disable_ema,
             inputs=[db_use_lora],
             outputs=[db_use_ema],
         )
 
         db_use_ema.change(
-            fn=lambda x: False if x else db_use_ema,
+            fn=disable_lora,
             inputs=[db_use_ema],
             outputs=[db_use_lora],
         )


### PR DESCRIPTION
This makes it behave so it does not crash webui. And works as intended.

It basically puts the Checkbox in a disabled state (preventing change events to trigger) till a value is assigned again.

Also fixes it up when 'disabled' values are set in db_config