### PR TITLE
Make UNET training optional

### DIFF
--- a/dreambooth/db_concept.py
+++ b/dreambooth/db_concept.py
@@ -39,11 +39,11 @@ class Concept(dict):
             self.instance_token = input_dict["instance_token"] if "instance_token" in input_dict else ""
             self.class_token = input_dict["class_token"] if "class_token" in input_dict else ""
             self.num_class_images = input_dict["num_class_images"] if "num_class_images" in input_dict else 0
-            self.class_negative_prompt = input_dict["class_negative_prompt"] if "class_negative_promt" in input_dict else ""
+            self.class_negative_prompt = input_dict["class_negative_prompt"] if "class_negative_prompt" in input_dict else ""
             self.class_guidance_scale = input_dict["class_guidance_scale"] if "class_guidance_scale" in input_dict else 7.5
             self.class_infer_steps = input_dict["class_infer_steps"] if "class_infer_steps" in input_dict else 60
             self.save_sample_negative_prompt = input_dict["save_sample_negative_prompt"] if "save_sample_negative_prompt" in input_dict else ""
-            self.n_save_sample = input_dict["n_save_sample"] if "n_save_samples" in input_dict else 1
+            self.n_save_sample = input_dict["n_save_sample"] if "n_save_sample" in input_dict else 1
             self.sample_seed = input_dict["sample_seed"] if "sample_seed" in input_dict else -1
             self.save_guidance_scale = input_dict["save_guidance_scale"] if "save_guidance_scale" in input_dict else 7.5
             self.save_infer_steps = input_dict["save_infer_steps"] if "save_infer_steps" in input_dict else 60

--- a/dreambooth/db_config.py
+++ b/dreambooth/db_config.py
@@ -68,6 +68,7 @@ class DreamboothConfig:
                  use_cpu: bool = False,
                  use_ema: bool = True,
                  use_lora: bool = False,
+                 use_unet: bool = True,
                  v2: bool = False,
                  c1_class_data_dir: str = "",
                  c1_class_guidance_scale: float = 7.5,
@@ -183,6 +184,7 @@ class DreamboothConfig:
         self.use_cpu = use_cpu
         self.use_ema = use_ema
         self.use_lora = use_lora
+        self.use_unet = False if use_unet is None else use_unet
         if scheduler is not None:
             self.scheduler = scheduler
 

--- a/dreambooth/db_config.py
+++ b/dreambooth/db_config.py
@@ -71,6 +71,7 @@ class DreamboothConfig:
                  use_lora: bool = False,
                  use_unet: bool = True,
                  use_stages: bool = False,
+                 stage_step_ratio: float = 1.0,
                  v2: bool = False,
                  c1_class_data_dir: str = "",
                  c1_class_guidance_scale: float = 7.5,
@@ -189,6 +190,7 @@ class DreamboothConfig:
         self.use_lora = False if use_lora is None else use_lora
         self.use_unet = False if use_unet is None else use_unet
         self.use_stages = False if use_stages is None else use_stages
+        self.stage_step_ratio = stage_step_ratio
         if scheduler is not None:
             self.scheduler = scheduler
 

--- a/dreambooth/db_config.py
+++ b/dreambooth/db_config.py
@@ -36,6 +36,8 @@ class DreamboothConfig:
                  has_ema: bool = False,
                  hflip: bool = False,
                  learning_rate: float = 0.00000172,
+                 lora_learning_rate: float = 1e-4,
+                 lora_txt_learning_rate: float = 1e-4,
                  lr_scheduler: str = 'constant',
                  lr_warmup_steps: int = 0,
                  max_token_length: int = 75,
@@ -148,6 +150,8 @@ class DreamboothConfig:
         self.half_model = half_model
         self.hflip = hflip
         self.learning_rate = learning_rate
+        self.lora_learning_rate = lora_learning_rate
+        self.lora_txt_learning_rate = lora_txt_learning_rate
         self.lr_scheduler = lr_scheduler
         self.lr_warmup_steps = lr_warmup_steps
         self.max_token_length = max_token_length

--- a/dreambooth/dreambooth.py
+++ b/dreambooth/dreambooth.py
@@ -338,7 +338,9 @@ def start_training(model_dir: str, lora_model_name: str, lora_alpha: int, imagic
     if msg:
         shared.state.textinfo = msg
         print(msg)
-        return msg, 0, msg
+        dirs = get_lora_models()
+        lora_model_name = gradio.Dropdown.update(choices=sorted(dirs), value=lora_model_name)
+        return lora_model_name, msg, 0, msg
 
     # Clear memory and do "stuff" only after we've ensured all the things are right
     print("Starting Dreambooth training...")

--- a/dreambooth/dreambooth.py
+++ b/dreambooth/dreambooth.py
@@ -345,7 +345,7 @@ def start_training(model_dir: str, lora_model_name: str, lora_alpha: float, lora
         msg = "Invalid Pretrained VAE Path."
     if config.resolution <= 0:
         msg = "Invalid resolution."
-    if config.train_in_stages and not config.train_unet or not config.train_text_encoder:
+    if config.train_in_stages and (not config.train_unet or not config.train_text_encoder):
         msg = "Multi-Stage training require both Train UNET and Train Text Encoder to be enable."
     if config.train_in_stages and config.use_lora:
         msg = "Multi-Stage training cannot continue if LoRA enabled, disable either one." # why use Multi-Stage when LoRA can be train on <= 8GB GPUs

--- a/dreambooth/dreambooth.py
+++ b/dreambooth/dreambooth.py
@@ -259,6 +259,7 @@ def load_params(model_dir):
                "db_use_cpu",
                "db_use_ema",
                "db_use_lora",
+               "db_use_unet",
                "c1_class_data_dir", "c1_class_guidance_scale", "c1_class_infer_steps",
                "c1_class_negative_prompt", "c1_class_prompt", "c1_class_token",
                "c1_instance_data_dir", "c1_instance_prompt", "c1_instance_token", "c1_max_steps", "c1_n_save_sample",

--- a/dreambooth/train_dreambooth.py
+++ b/dreambooth/train_dreambooth.py
@@ -557,8 +557,12 @@ def main(args: DreamboothConfig, memory_record, use_subdir, lora_model=None, lor
     if not args.train_text_encoder:
         text_encoder.requires_grad_(False)
 
+    if not args.use_unet:
+        unet.requires_grad_(False)        
+
     if args.gradient_checkpointing:
-        unet.enable_gradient_checkpointing()
+        if args.use_unet:
+            unet.enable_gradient_checkpointing()
         if args.train_text_encoder:
             text_encoder.gradient_checkpointing_enable()
 
@@ -611,8 +615,9 @@ def main(args: DreamboothConfig, memory_record, use_subdir, lora_model=None, lor
         )
     else:
         params_to_optimize = (
-            itertools.chain(unet.parameters(), text_encoder.parameters()) if args.train_text_encoder
-            else unet.parameters()
+            itertools.chain(text_encoder.parameters()) if args.train_text_encoder and not args.use_unet else 
+            itertools.chain(unet.parameters(), text_encoder.parameters()) if args.train_text_encoder else 
+            unet.parameters()
         )
     optimizer = optimizer_class(
         params_to_optimize,
@@ -821,9 +826,9 @@ def main(args: DreamboothConfig, memory_record, use_subdir, lora_model=None, lor
 
     # Train!
     total_batch_size = args.train_batch_size * accelerator.num_processes * args.gradient_accumulation_steps
-    stats = f"CPU: {args.use_cpu} Adam: {use_adam}, Prec: {args.mixed_precision}, " \
-            f"Grad: {args.gradient_checkpointing}, TextTr: {args.train_text_encoder} EM: {args.use_ema}, " \
-            f"LR: {args.learning_rate} LORA:{args.use_lora}"
+    stats = f"CPU: {args.use_cpu}, Adam: {use_adam}, Prec: {args.mixed_precision}, " \
+            f"Grad: {args.gradient_checkpointing}, TextTr: {args.train_text_encoder}, EM: {args.use_ema}, " \
+            f"LR: {args.learning_rate}, LORA: {args.use_lora}, UNET: {args.use_unet}"
 
     print("***** Running training *****")
     print(f"  Num examples = {len(train_dataset)}")
@@ -972,12 +977,13 @@ def main(args: DreamboothConfig, memory_record, use_subdir, lora_model=None, lor
         if training_complete:
             break
         try:
-            unet.train()
+            if args.use_unet:
+                unet.train()
             if args.train_text_encoder and text_encoder is not None:
                 text_encoder.train()
             for step, batch in enumerate(train_dataloader):
                 weights_saved = False
-                with accelerator.accumulate(unet):
+                with accelerator.accumulate(unet), accelerator.accumulate(text_encoder):
                     # Convert images to latent space
                     with torch.no_grad():
                         if not args.not_cache_latents:

--- a/dreambooth/train_dreambooth.py
+++ b/dreambooth/train_dreambooth.py
@@ -553,6 +553,7 @@ def main(args: DreamboothConfig, memory_record, use_subdir, lora_model=None, lor
 
     unet_lora_params = None
     text_encoder_lora_params = None
+    args.pad_tokens = args.train_text_encoder
 
     if not args.train_text_encoder:
         text_encoder.requires_grad_(False)

--- a/dreambooth/train_dreambooth.py
+++ b/dreambooth/train_dreambooth.py
@@ -33,7 +33,7 @@ from extensions.sd_dreambooth_extension.dreambooth.finetune_utils import Filenam
 from extensions.sd_dreambooth_extension.dreambooth.utils import cleanup, list_features, get_images
 from extensions.sd_dreambooth_extension.lora_diffusion.lora import weight_apply_lora, inject_trainable_lora, \
     save_lora_weight
-from modules import shared, paths
+from modules import shared, paths, images
 
 # Custom stuff
 try:
@@ -45,9 +45,7 @@ pil_features = list_features()
 mem_record = {}
 with_prior = False
 
-# End custom stuff
-
-torch.backends.cudnn.benchmark = True
+torch.backends.cudnn.benchmark = False
 
 logger = logging.getLogger(__name__)
 # define a Handler which writes DEBUG messages or higher to the sys.stderr
@@ -605,8 +603,8 @@ def main(args: DreamboothConfig, memory_record, use_subdir, lora_model=None, lor
 
     if args.use_lora:
         params_to_optimize = ([
-                {"params": itertools.chain(*unet_lora_params), "lr": 1e-4},
-                {"params": itertools.chain(*text_encoder_lora_params), "lr": 5e-6,},
+                {"params": itertools.chain(*unet_lora_params), "lr": args.lora_learning_rate},
+                {"params": itertools.chain(*text_encoder_lora_params), "lr": args.lora_txt_learning_rate},
             ]
             if args.train_text_encoder
             else itertools.chain(*unet_lora_params)

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -112,6 +112,8 @@ def on_ui_tabs():
                         with gr.Column():
                             gr.HTML(value="Learning Rate")
                             db_learning_rate = gr.Number(label='Learning Rate', value=2e-6)
+                            db_lora_learning_rate = gr.Number(label='Lora unet Learning Rate', value=2e-4)
+                            db_lora_txt_learning_rate = gr.Number(label='Lora Text Encoder Learning Rate', value=2e-4)
                             db_scale_lr = gr.Checkbox(label="Scale Learning Rate", value=False)
                             db_lr_scheduler = gr.Dropdown(label="Learning Rate Scheduler", value="constant",
                                                           choices=["linear", "cosine", "cosine_with_restarts",
@@ -249,6 +251,8 @@ def on_ui_tabs():
                 db_has_ema,
                 db_hflip,
                 db_learning_rate,
+                db_lora_learning_rate,
+                db_lora_txt_learning_rate,
                 db_lr_scheduler,
                 db_lr_warmup_steps,
                 db_max_token_length,
@@ -358,6 +362,8 @@ def on_ui_tabs():
                 db_half_model,
                 db_hflip,
                 db_learning_rate,
+                db_lora_learning_rate,
+                db_lora_txt_learning_rate,
                 db_lr_scheduler,
                 db_lr_warmup_steps,
                 db_max_token_length,
@@ -603,6 +609,7 @@ def on_ui_tabs():
                 db_use_subdir
             ],
             outputs=[
+                db_lora_model_name,
                 db_status,
                 db_revision
             ]

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -147,6 +147,7 @@ def on_ui_tabs():
                                     db_use_cpu = gr.Checkbox(label="Use CPU Only (SLOW)", value=False)
                                     db_use_lora = gr.Checkbox(label="Use LORA", value=False)
                                     db_use_ema = gr.Checkbox(label="Use EMA", value=False)
+                                    db_use_unet = gr.Checkbox(label="Use UNET", value=True)
                                     db_use_8bit_adam = gr.Checkbox(label="Use 8bit Adam", value=False)
                                     db_mixed_precision = gr.Dropdown(label="Mixed Precision", value="no",
                                                                      choices=list_floats())
@@ -283,6 +284,7 @@ def on_ui_tabs():
                 db_use_cpu,
                 db_use_ema,
                 db_use_lora,
+                db_use_unet,
                 db_v2,
                 c1_class_data_dir,
                 c1_class_guidance_scale,
@@ -390,6 +392,7 @@ def on_ui_tabs():
                 db_use_cpu,
                 db_use_ema,
                 db_use_lora,
+                db_use_unet,
                 c1_class_data_dir,
                 c1_class_guidance_scale,
                 c1_class_infer_steps,

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -154,6 +154,7 @@ def on_ui_tabs():
                                     db_use_unet = gr.Checkbox(label="Use UNET", value=True)
                                     db_use_8bit_adam = gr.Checkbox(label="Use 8bit Adam", value=False)
                                     db_use_stages = gr.Checkbox(label="Train UNET and Text Encoder Separately", value=False)
+                                    db_stage_step_ratio = gr.Slider(label="Step ratio of text encoder training", minimum=0, maximum=2, step=0.01, value=1, visible=False)
                                     db_mixed_precision = gr.Dropdown(label="Mixed Precision", value="no",
                                                                      choices=list_floats())
                                     db_attention = gr.Dropdown(
@@ -292,6 +293,7 @@ def on_ui_tabs():
                 db_use_lora,
                 db_use_unet,
                 db_use_stages,
+                db_stage_step_ratio,
                 db_v2,
                 c1_class_data_dir,
                 c1_class_guidance_scale,
@@ -402,6 +404,7 @@ def on_ui_tabs():
                 db_use_lora,
                 db_use_unet,
                 db_use_stages,
+                db_stage_step_ratio,
                 c1_class_data_dir,
                 c1_class_guidance_scale,
                 c1_class_infer_steps,
@@ -482,6 +485,14 @@ def on_ui_tabs():
             fn=disable_lora,
             inputs=[db_use_ema],
             outputs=[db_use_lora],
+        )
+
+        db_use_stages.change(
+            fn=lambda x: {
+                db_stage_step_ratio: gr_show(x is True)
+            },
+            inputs=[db_use_stages],
+            outputs=[db_stage_step_ratio]
         )
 
         db_create_from_hub.change(


### PR DESCRIPTION
This is still a working progress, but it makes unet training optional.

This allows one to train in multiple steps when you dont have enough VRAM.

For example, where training the UNET and Text encoder is not possible on a 10GB VRAM GPU, this can get you close to that by training the Text Encoder first and then the UNET. I only have a 10GB 3080 and currently I can achieve quite good results in < 20 minutes of training on a subject. 


There is still a lot of testing to be done to find out what are good steps and learning rates to use.

This feature is NOT user friendly at this point of time.