### PR TITLE
Allow saving both lora and checkpoints with custom names

### DIFF
--- a/dreambooth/db_config.py
+++ b/dreambooth/db_config.py
@@ -28,6 +28,7 @@ class DreamboothConfig:
                  attention: str = "default",
                  center_crop: bool = True,
                  concepts_path: str = "",
+                 custom_model_name: str = "",
                  epoch_pause_frequency: int = 0,
                  epoch_pause_time: int = 0,
                  gradient_accumulation_steps: int = 1,
@@ -143,6 +144,7 @@ class DreamboothConfig:
         self.attention = attention
         self.center_crop = center_crop
         self.concepts_path = concepts_path
+        self.custom_model_name = custom_model_name
         self.epoch_pause_frequency = epoch_pause_frequency
         self.epoch_pause_time = epoch_pause_time
         self.gradient_accumulation_steps = gradient_accumulation_steps

--- a/dreambooth/diff_to_sd.py
+++ b/dreambooth/diff_to_sd.py
@@ -275,9 +275,12 @@ def compile_checkpoint(model_name: str, half: bool, use_subdir: bool = False, lo
     shared.state.job_no = 0
     shared.state.job_count = 7
 
-    model_name = custom_model_name if not "" else model_name
+    save_model_name = model_name if custom_model_name == "" else custom_model_name
+    if custom_model_name == "":
+        printi(f"Compiling checkpoint for {model_name}...")
+    else:
+        printi(f"Compiling checkpoint for {model_name} with a custom name {custom_model_name}")
 
-    printi(f"Compiling checkpoint for {model_name}...")
     if not model_name:
         return "Select a model to compile.", "No model selected."
 
@@ -293,10 +296,10 @@ def compile_checkpoint(model_name: str, half: bool, use_subdir: bool = False, lo
     v2 = config.v2
     total_steps = config.revision
     if use_subdir:
-        os.makedirs(os.path.join(models_path, model_name), exist_ok=True)
-        checkpoint_path = os.path.join(models_path, model_name, f"{model_name}_{total_steps}.ckpt")
+        os.makedirs(os.path.join(models_path, save_model_name), exist_ok=True)
+        checkpoint_path = os.path.join(models_path, save_model_name, f"{save_model_name}_{total_steps}.ckpt")
     else:
-        checkpoint_path = os.path.join(models_path, f"{model_name}_{total_steps}.ckpt")
+        checkpoint_path = os.path.join(models_path, f"{save_model_name}_{total_steps}.ckpt")
 
     model_path = config.pretrained_model_name_or_path
     unet_path = osp.join(model_path, "unet", "diffusion_pytorch_model.bin")

--- a/dreambooth/diff_to_sd.py
+++ b/dreambooth/diff_to_sd.py
@@ -257,7 +257,7 @@ def convert_text_enc_state_dict(text_enc_dict: dict[str, torch.Tensor]):
     return text_enc_dict
 
 
-def compile_checkpoint(model_name: str, half: bool, use_subdir: bool = False, lora_path=None, lora_alpha=1,
+def compile_checkpoint(model_name: str, half: bool, use_subdir: bool = False, lora_path=None, lora_alpha=1, custom_model_name="",
                        reload_models=True, log=True):
     """
 
@@ -274,6 +274,9 @@ def compile_checkpoint(model_name: str, half: bool, use_subdir: bool = False, lo
     shared.state.textinfo = "Compiling checkpoint."
     shared.state.job_no = 0
     shared.state.job_count = 7
+
+    model_name = custom_model_name if not "" else model_name
+
     printi(f"Compiling checkpoint for {model_name}...")
     if not model_name:
         return "Select a model to compile.", "No model selected."

--- a/dreambooth/dreambooth.py
+++ b/dreambooth/dreambooth.py
@@ -224,6 +224,7 @@ def load_params(model_dir):
                "db_attention",
                "db_center_crop",
                "db_concepts_path",
+               "db_custom_model_name",
                "db_epoch_pause_frequency",
                "db_epoch_pause_time",
                "db_gradient_accumulation_steps",
@@ -307,7 +308,7 @@ def load_model_params(model_dir):
                ""
 
 
-def start_training(model_dir: str, lora_model_name: str, lora_alpha: int, imagic_only: bool, use_subdir: bool):
+def start_training(model_dir: str, lora_model_name: str, lora_alpha: int, imagic_only: bool, use_subdir: bool, custom_model_name: str):
     global mem_record
     if model_dir == "" or model_dir is None:
         print("Invalid model name.")
@@ -343,6 +344,7 @@ def start_training(model_dir: str, lora_model_name: str, lora_alpha: int, imagic
         return lora_model_name, msg, 0, msg
 
     # Clear memory and do "stuff" only after we've ensured all the things are right
+    print(f"Custom model name is {custom_model_name}")
     print("Starting Dreambooth training...")
     unload_system_models()
     total_steps = config.revision
@@ -358,7 +360,7 @@ def start_training(model_dir: str, lora_model_name: str, lora_alpha: int, imagic
             print(shared.state.textinfo)
             from extensions.sd_dreambooth_extension.dreambooth.train_dreambooth import main
             config, mem_record, msg = main(config, mem_record, use_subdir=use_subdir, lora_model=lora_model_name,
-                                           lora_alpha=lora_alpha)
+                                           lora_alpha=lora_alpha, custom_model_name=custom_model_name)
             if config.revision != total_steps:
                 config.save()
         total_steps = config.revision

--- a/dreambooth/train_dreambooth.py
+++ b/dreambooth/train_dreambooth.py
@@ -901,7 +901,9 @@ def main(args: DreamboothConfig, memory_record, use_subdir, lora_model=None, lor
                             s_pipeline.save_pretrained(args.pretrained_model_name_or_path)
 
                             compile_checkpoint(args.model_name, half=args.half_model, use_subdir=use_subdir,
-                                               reload_models=False, lora_path=out_file, log=False)
+                                               reload_models=False, lora_path=out_file, log=False,
+                                               custom_model_name=args.custom_model_name
+                                               )
                         if args.use_ema:
                             ema_unet.restore(unet.parameters())
 

--- a/dreambooth/train_dreambooth.py
+++ b/dreambooth/train_dreambooth.py
@@ -898,7 +898,8 @@ def main(args: DreamboothConfig, memory_record, use_subdir, lora_model=None, lor
                             s_pipeline.save_pretrained(args.pretrained_model_name_or_path)
 
                         compile_checkpoint(args.model_name, half=args.half_model, use_subdir=use_subdir,
-                                           reload_models=False, lora_path=out_file, log=False)
+                                           reload_models=False, lora_path=out_file, log=False, 
+                                           custom_model_name=args.custom_model_name)
                         if args.use_ema:
                             ema_unet.restore(unet.parameters())
 

--- a/dreambooth/train_dreambooth.py
+++ b/dreambooth/train_dreambooth.py
@@ -900,14 +900,8 @@ def main(args: DreamboothConfig, memory_record, use_subdir, lora_model=None, lor
                             shared.state.textinfo = f"Saving diffusion model at step {args.revision}..."
                             s_pipeline.save_pretrained(args.pretrained_model_name_or_path)
 
-<<<<<<< HEAD
-                        compile_checkpoint(args.model_name, half=args.half_model, use_subdir=use_subdir,
-                                           reload_models=False, lora_path=out_file, log=False, 
-                                           custom_model_name=args.custom_model_name)
-=======
                             compile_checkpoint(args.model_name, half=args.half_model, use_subdir=use_subdir,
                                                reload_models=False, lora_path=out_file, log=False)
->>>>>>> dev
                         if args.use_ema:
                             ema_unet.restore(unet.parameters())
 

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -586,12 +586,6 @@ def on_ui_tabs():
             ]
         )
 
-        db_custom_model_name.change(
-            fn=lambda n: n,
-            inputs="text",
-            outputs="text"
-            )
-
         db_create_model.click(
             fn=wrap_gradio_gpu_call(extract_checkpoint),
             _js="db_start_progress",
@@ -618,7 +612,8 @@ def on_ui_tabs():
                 db_lora_model_name,
                 db_lora_weight,
                 db_train_imagic_only,
-                db_use_subdir
+                db_use_subdir,
+                db_custom_model_name
             ],
             outputs=[
                 db_lora_model_name,

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -35,6 +35,7 @@ def on_ui_tabs():
                         "choices": sorted(get_lora_models())},
                                           "refresh_lora_models")
                 db_custom_model_name = gr.Textbox(label="Custom Model Name", 
+                    value="",
                     placeholder="Enter a model name for saving checkpoints and lora models.")
                 db_lora_weight = gr.Slider(label="Lora Weight", value=1, minimum=0.1, maximum=1, step=0.1)
                 db_half_model = gr.Checkbox(label="Half Model", value=False)
@@ -576,7 +577,8 @@ def on_ui_tabs():
                 db_half_model,
                 db_use_subdir,
                 db_lora_model_name,
-                db_lora_weight
+                db_lora_weight,
+                db_custom_model_name
             ],
             outputs=[
                 db_status,

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -34,6 +34,8 @@ def on_ui_tabs():
                     create_refresh_button(db_lora_model_name, get_lora_models, lambda: {
                         "choices": sorted(get_lora_models())},
                                           "refresh_lora_models")
+                db_custom_model_name = gr.Textbox(label="Custom Model Name", 
+                    placeholder="Enter a model name for saving checkpoints and lora models.")
                 db_lora_weight = gr.Slider(label="Lora Weight", value=1, minimum=0.1, maximum=1, step=0.1)
                 db_half_model = gr.Checkbox(label="Half Model", value=False)
                 db_use_subdir = gr.Checkbox(label="Save Checkpoint to Subdirectory", value=False)
@@ -243,6 +245,7 @@ def on_ui_tabs():
                 db_attention,
                 db_center_crop,
                 db_concepts_path,
+                db_custom_model_name,
                 db_epoch_pause_frequency,
                 db_epoch_pause_time,
                 db_gradient_accumulation_steps,
@@ -355,6 +358,7 @@ def on_ui_tabs():
                 db_attention,
                 db_center_crop,
                 db_concepts_path,
+                db_custom_model_name,
                 db_epoch_pause_frequency,
                 db_epoch_pause_time,
                 db_gradient_accumulation_steps,
@@ -579,6 +583,12 @@ def on_ui_tabs():
                 db_outcome
             ]
         )
+
+        db_custom_model_name.change(
+            fn=lambda n: n,
+            inputs="text",
+            outputs="text"
+            )
 
         db_create_model.click(
             fn=wrap_gradio_gpu_call(extract_checkpoint),


### PR DESCRIPTION
Builds off of PR https://github.com/d8ahazard/sd_dreambooth_extension/pull/532

Currently saving checkpoints will use the diffusers name. 
Due to the lora additions, it can be pretty hard to track which projects you're working on.

This adds a textbox field that allows you to enter a custom name. 
If it's empty, it should default to the default saving functionality as before. 
When using lora, it will also name it under the same scheme to better track projects.

Saving and loading params should also be supported properly as well, but let me know if you find any weird edge cases or pitfalls.  