### PR TITLE
Perf fixes

### DIFF
--- a/dreambooth/train_dreambooth.py
+++ b/dreambooth/train_dreambooth.py
@@ -723,7 +723,7 @@ def main(args: DreamboothConfig, memory_record, use_subdir, lora_model=None, lor
         if enc_vae is None:
             enc_vae = create_vae()
 
-        if orig_dataset is not None:
+        if orig_dataset is None:
             dataset = SuperDataset(
                 concepts_list=args.concepts_list,
                 tokenizer=tokenizer,
@@ -736,7 +736,7 @@ def main(args: DreamboothConfig, memory_record, use_subdir, lora_model=None, lor
                 shuffle_tags=args.shuffle_tags
             )
         else:
-            dataset = gen_dataset
+            dataset = orig_dataset
 
         dataloader = torch.utils.data.DataLoader(
             dataset, batch_size=args.train_batch_size, shuffle=True, collate_fn=collate_fn, pin_memory=True

--- a/dreambooth/train_dreambooth.py
+++ b/dreambooth/train_dreambooth.py
@@ -977,7 +977,7 @@ def main(args: DreamboothConfig, memory_record, use_subdir, lora_model=None, lor
                 text_encoder.train()
             for step, batch in enumerate(train_dataloader):
                 weights_saved = False
-                with accelerator.accumulate(unet):
+                with accelerator.accumulate(unet), accelerator.accumulate(text_encoder):
                     # Convert images to latent space
                     with torch.no_grad():
                         if not args.not_cache_latents:


### PR DESCRIPTION
1. The cache latents logic was wrong and would create the dataset over and over for no reason. This would also get insanely slow with a large amount of class/prior images.
2. The text encoder was not accumulated for gradient checkpointing. Enabling this without even training the text encoder saves a little VRAM and allows me to run 2 steps instead of 1.