### PR TITLE
Set warmup steps to 0 by default. Add extra tooltip info on why it could be bad

### DIFF
--- a/javascript/dreambooth.js
+++ b/javascript/dreambooth.js
@@ -79,7 +79,7 @@ new_titles = {
     "Instance Prompt": "A prompt describing the subject. Use [Filewords] to parse image filename/.txt to insert existing prompt here.",
     "Instance Token": "When using [filewords], this is the instance identifier that is unique to your subject. Should be a single word.",
     "Learning Rate Scheduler": "The learning rate scheduler to use.",
-    "Learning Rate Warmup Steps": "Number of steps for the warmup in the lr scheduler.",
+    "Learning Rate Warmup Steps": "Number of steps for the warmup in the lr scheduler. Applies to all schedulers except constant.",
     "Learning Rate": "The rate at which the model learns. Default is 0.000005. Use a lower value like 0.000002 or 0.000001 for more complex subjects...like people.",
     "Load Params": "Load last saved training parameters for the model..",
     "Log Memory": "Log the current GPU memory usage.",

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -123,7 +123,7 @@ def on_ui_tabs():
                                                           choices=["linear", "cosine", "cosine_with_restarts",
                                                                    "polynomial", "constant",
                                                                    "constant_with_warmup"])
-                            db_lr_warmup_steps = gr.Number(label="Learning Rate Warmup Steps", precision=0, value=500)
+                            db_lr_warmup_steps = gr.Number(label="Learning Rate Warmup Steps", precision=0, value=0)
 
                         with gr.Column():
                             gr.HTML(value="Image Processing")


### PR DESCRIPTION
Warmup steps applies to all schedulers except the constant without warmup. 

This caused greate confusion testing other schedulers and not realizing the default effectively runs for a long time with the default of 500.



