### PR TITLE
Make sure dataloader is prepared again after caching latents

### DIFF
--- a/dreambooth/train_dreambooth.py
+++ b/dreambooth/train_dreambooth.py
@@ -763,7 +763,7 @@ def main(args: DreamboothConfig, memory_record, use_subdir, lora_model=None, lor
                     text_encoder_cache.append(text_encoder(d_batch["input_ids"])[0])
                 concepts_cache.append(dataset.current_concept)
         dataset = LatentsDataset(latents_cache, text_encoder_cache, concepts_cache)
-        dataloader = torch.utils.data.DataLoader(dataset, batch_size=1, collate_fn=lambda z: z, shuffle=True)
+        dataloader = accelerator.prepare(torch.utils.data.DataLoader(dataset, batch_size=1, collate_fn=lambda z: z, shuffle=True))
         if enc_vae is not None:
             del enc_vae
         return dataset, dataloader


### PR DESCRIPTION
From some discussion on the #548 PR, I was testing the behavior today. 

I then noticed that gradient accumalation was only happening for the first epoch. 

(see  https://github.com/d8ahazard/sd_dreambooth_extension/commit/1426d144cd0bf370d18f8656991730a35deceaf4#commitcomment-93219200 )

Finally tracked this down to the new dataloader created in `cache_latents` and need it to be prepared again so that `accelerator.accumalate` works correctly. 