### PR TITLE
Make backwards compatable with python 3.8

### DIFF
--- a/dreambooth/diff_to_sd.py
+++ b/dreambooth/diff_to_sd.py
@@ -7,6 +7,7 @@ import os.path as osp
 import re
 import shutil
 import traceback
+from typing import Dict
 
 import torch
 from diffusers import DiffusionPipeline
@@ -211,7 +212,7 @@ textenc_pattern = re.compile("|".join(protected.keys()))
 code2idx = {'q': 0, 'k': 1, 'v': 2}
 
 
-def convert_text_enc_state_dict_v20(text_enc_dict: dict[str, torch.Tensor]):
+def convert_text_enc_state_dict_v20(text_enc_dict: Dict[str, torch.Tensor]):
     new_state_dict = {}
     capture_qkv_weight = {}
     capture_qkv_bias = {}
@@ -253,7 +254,7 @@ def convert_text_enc_state_dict_v20(text_enc_dict: dict[str, torch.Tensor]):
     return new_state_dict
 
 
-def convert_text_enc_state_dict(text_enc_dict: dict[str, torch.Tensor]):
+def convert_text_enc_state_dict(text_enc_dict: Dict[str, torch.Tensor]):
     return text_enc_dict
 
 


### PR DESCRIPTION
Some implementations of automatic1111 are on python 3.8 instead of 3.10.
This should make the dreambooth extension compatible with those on 3.8.

I am sure there are more compatibility issues but this is the only one I have run into.

Should relieve some of the issues here:
https://github.com/TheLastBen/fast-stable-diffusion/issues/914

Potentially we could just remove the type hints if you wanted to support back to <3.5 but I haven't seen anyone go that far back: 
https://stackoverflow.com/a/63460173