### PR TITLE
Remove gradio from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,6 @@ font-roboto
 fonts
 ftfy==6.1.1
 gfpgan==1.3.8
-gradio==3.9
 inflection==0.5.1
 jsonmerge==1.8.0
 kornia==0.6.7


### PR DESCRIPTION
gradio installed in the WEB UI has been updated to 3.15.0.　( https://github.com/AUTOMATIC1111/stable-diffusion-webui/commit/76f256fe8f844641f4e9b41f35c7dd2cba5090d6 )
If it is defined on the extension side, it seems to be overwritten by an older version.

