### PR TITLE
Rework of stop text encoder and fix to reported total batch size

### DIFF
--- a/dreambooth/db_config.py
+++ b/dreambooth/db_config.py
@@ -78,7 +78,7 @@ class DreamboothConfig:
                  src: str = "",
                  shuffle_tags: bool = False,
                  train_batch_size: int = 1,
-                 stop_text_encoder: int = 0,
+                 stop_text_encoder: float = 1.0,
                  use_8bit_adam: bool = True,
                  use_concepts: bool = False,
                  use_ema: bool = True,

--- a/javascript/dreambooth.js
+++ b/javascript/dreambooth.js
@@ -239,7 +239,7 @@ let db_titles = {
     "Shuffle Tags": "When enabled, tags after the first ',' in a prompt will be randomly ordered, which can potentially improve training.",
     "Shuffle After Epoch": "When enabled, will shuffle the dataset after the first epoch. Will enable text encoder training and latent caching (More VRAM).",
     "Source Checkpoint": "The source checkpoint to extract for training.",
-    "Text Encoder Epochs": "The number of steps per image (Epoch) to train the text encoder for. Set to -1 to train the same amount as the Unet, set to 0 to not train at all.",
+    "Step Ratio of Text Encoder Training": "The number of steps per image (Epoch) to train the text encoder for. Set 0.5 for 50% of the epochs",
     "Total Number of Class/Reg Images": "Total number of classification/regularization images to use. If no images exist, they will be generated. Set to 0 to disable prior preservation.",
     "Train Text Encoder": "Enabling this will provide better results and editability, but cost more VRAM.",
     "Train": "Start training.",

--- a/scripts/api.py
+++ b/scripts/api.py
@@ -133,7 +133,7 @@ class DreamboothParameters(BaseModel):
     src: Union[str, None] = ""
     shuffle_tags: bool = False
     train_batch_size: int = 1
-    stop_text_encoder: int = 0
+    stop_text_encoder: float = 0
     use_8bit_adam: bool = False
     use_lora: bool = False
     use_subdir: bool = True

--- a/scripts/dreambooth.py
+++ b/scripts/dreambooth.py
@@ -234,15 +234,15 @@ def performance_wizard(model_name):
     if has_xformers:
         attention = "xformers"
     try:
-        stop_text_encoder = 75
+        stop_text_encoder = 0.75
         if config is not None:
-            stop_text_encoder = int(config.num_train_epochs * .75)
+            stop_text_encoder = 0.75
         t = torch.cuda.get_device_properties(0).total_memory
         gb = math.ceil(t / 1073741824)
         print(f"Total VRAM: {gb}")
         if gb >= 24:
             sample_batch_size = 4
-            stop_text_encoder = 75
+            stop_text_encoder = 0.75
             use_ema = True
             if attention != "xformers":
                 attention = "no"
@@ -266,7 +266,7 @@ def performance_wizard(model_name):
                 "Accumulation Steps": gradient_accumulation_steps, "Precision": mixed_precision,
                 "Cache Latents": cache_latents, "Training Batch Size": train_batch_size,
                 "Class Generation Batch Size": sample_batch_size,
-                "Text Encoder Epochs": stop_text_encoder, "8Bit Adam": use_8bit_adam, "EMA": use_ema, "LORA": use_lora}
+                "Text Encoder Ratio": stop_text_encoder, "8Bit Adam": use_8bit_adam, "EMA": use_ema, "LORA": use_lora}
     for key in log_dict:
         msg += f"<br>{key}: {log_dict[key]}"
     return attention, gradient_checkpointing, gradient_accumulation_steps, mixed_precision, cache_latents, \

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -310,7 +310,7 @@ def on_ui_tabs():
                                         label="Memory Attention", value="default",
                                         choices=list_attention())
                                     db_cache_latents = gr.Checkbox(label="Cache Latents", value=True)
-                                    db_stop_text_encoder = gr.Number(label="Text Encoder Epochs", value=-1)
+                                    db_stop_text_encoder = gr.Slider(label="Step Ratio of Text Encoder Training", minimum=0, maximum=1, step=0.01, value=1, visible=True)
                                     db_clip_skip = gr.Slider(label="Clip Skip", value=1, minimum=1, maximum=12, step=1)
                                     db_prior_loss_weight = gr.Number(label="Prior Loss Weight", value=1.0, precision=1)
                                     db_pad_tokens = gr.Checkbox(label="Pad Tokens", value=True)
@@ -402,8 +402,8 @@ def on_ui_tabs():
                 db_check_progress = gr.Button("Check Progress", elem_id=f"db_check_progress", visible=False)
                 db_update_params = gr.Button("Update Parameters", elem_id="db_update_params", visible=False)
 
-                def check_toggles(use_ema, use_lora, lr_scheduler, stop_text_enc):
-                    pad_tokens = update_pad_tokens(stop_text_enc)
+                def check_toggles(use_ema, use_lora, lr_scheduler, stop_text_encoder):
+                    pad_tokens = update_pad_tokens(stop_text_encoder)
                     show_ema, lora_save, lora_lr, lora_model = disable_ema(use_lora)
                     if not use_lora and use_ema:
                         disable_lora(use_ema)


### PR DESCRIPTION
Instead of using a fixed epoch stop, the text encoder stops training in relation to the epochs to be trained.
If i train 10 epoch, with the ratio at 0.2, the text encode training will be on only the first 2 epochs