### PR TITLE
Fix LoRA text weights not saving.

### DIFF
--- a/dreambooth/diff_to_sd.py
+++ b/dreambooth/diff_to_sd.py
@@ -344,7 +344,7 @@ def compile_checkpoint(model_name: str, half: bool, use_subdir: bool = False, lo
             lora_txt = lora_path.replace(".pt", "_txt.pt")
             if os.path.exists(lora_txt):
                 printi(f"Applying lora weight of alpha: {lora_txt_alpha} to text encoder...", log=log)
-                weight_apply_lora(loaded_pipeline.text_encoder, torch.load(lora_txt), alpha=lora_txt_alpha)
+                weight_apply_lora(loaded_pipeline.text_encoder, torch.load(lora_txt), target_replace_module=["CLIPAttention"], alpha=lora_txt_alpha)
                 printi("Saving lora text encoder...", log=log)
                 loaded_pipeline.text_encoder.save_pretrained(
                     os.path.join(config.pretrained_model_name_or_path, "text_encoder_lora"))


### PR DESCRIPTION
LoRA weights weren't saving when going from Diffusers to CKPT. This was resulting in the alphas of `1` being applied twice to the unet if you chose to train the text encoder.
Should resolve some headaches :upside_down_face: .