### PR TITLE
Fix broken Imagic training

### DIFF
--- a/dreambooth/train_imagic.py
+++ b/dreambooth/train_imagic.py
@@ -323,8 +323,8 @@ def train_imagic(args: DreamboothConfig):
         accelerator.unwrap_model(unet).parameters(),
         lr=args.learning_rate
     )
-    # Accelerator.prepare takes a list?
-    optimizer = accelerator.prepare([optimizer])
+
+    optimizer = accelerator.prepare(optimizer)
     progress_bar = tqdm(range(args.num_train_epochs), disable=not accelerator.is_local_main_process)
     progress_bar.set_description("Fine Tuning")
     status.textinfo = "Fine Tuning"


### PR DESCRIPTION
Currently, training _Imagic_ will always throw this error: `AttributeError: 'list' object has no attribute 'step'`. This should be fixed with this PR.

[`Accelerator.prepare`](https://huggingface.co/docs/accelerate/v0.14.0/en/package_reference/accelerator#accelerate.Accelerator.prepare) does not accept a `list`, instead it should be `*args`. Hence this fix.