### PR TITLE
Generate Tab: Sample generation use settings resolution

### DIFF
--- a/apidoc.json
+++ b/apidoc.json
@@ -685,6 +685,18 @@
             "in": "query"
           },
           {
+            "description": "The resolution used when generating samples",
+            "required": false,
+            "schema": {
+              "title": "Resolution",
+              "type": "integer",
+              "description": "The resolution used when generating samples, it will be converted to (resolution, resolution)",
+              "default": 512
+            },
+            "name": "resolution",
+            "in": "query"
+          },
+          {
             "description": "Number of sampling steps to use when generating images.",
             "required": false,
             "schema": {

--- a/javascript/dreambooth.js
+++ b/javascript/dreambooth.js
@@ -85,7 +85,7 @@ function db_start(numArgs, save, startProgress, args) {
 }
 
 function db_start_sample() {
-    return db_start(11, false, true, arguments);
+    return db_start(12, false, true, arguments);
 }
 
 // Performance wizard

--- a/scripts/dreambooth.py
+++ b/scripts/dreambooth.py
@@ -283,7 +283,8 @@ def ui_samples(model_dir: str,
                negative_prompt: str = "",
                seed: int = -1,
                steps: int = 60,
-               scale: float = 7.5
+               scale: float = 7.5,
+               resolution: int = 512
                ):
 
     if sample_batch_size > num_samples:
@@ -313,7 +314,7 @@ def ui_samples(model_dir: str,
                 lora_weight,
                 lora_txt_weight,
                 batch_size)
-            status.textinfo = f"Generating sample image for model {config.model_name}..."
+            status.textinfo = f"Generating sample {resolution} image for model {config.model_name}..."
             status.sampling_steps = 0
             status.current_image_sampling_step = 0
             pd = PromptData()
@@ -322,6 +323,7 @@ def ui_samples(model_dir: str,
             pd.negative_prompt = negative_prompt
             pd.scale = scale
             pd.seed = seed
+            pd.resolution = (resolution, resolution)
             prompts = [pd] * batch_size
             while len(images) < num_samples:
                 prompts_out.append(save_sample_prompt)

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -910,7 +910,8 @@ def on_ui_tabs():
                     db_sample_negative,
                     db_sample_seed,
                     db_sample_steps,
-                    db_sample_scale],
+                    db_sample_scale,
+                    db_resolution],
             outputs=[db_gallery, db_prompt_list, db_status]
         )
 


### PR DESCRIPTION
- use settings resolution for sample image creation
- may require the recreation of sample images due to the use of a resolution (tuple int) parameter change. 
- add sample size to notification in output window

I was unsure if the image generation was due to the parameter change or another change to the repository that is unrelated.

This allows me to skip using the txt2img prompt and creating checkpoints. I train a lot at 768 and this saves a lot of time and disk space