### PR TITLE
Update YAML configs to enable proper training 

### DIFF
--- a/configs/v1-inference.yaml
+++ b/configs/v1-inference.yaml
@@ -7,11 +7,11 @@ model:
     num_timesteps_cond: 1
     log_every_t: 200
     timesteps: 1000
-    first_stage_key: "jpg"
-    cond_stage_key: "txt"
+    first_stage_key: "image"
+    cond_stage_key: "caption"
     image_size: 64
     channels: 4
-    cond_stage_trainable: false   # Note: different from the one we trained before
+    cond_stage_trainable: true   # Note: different from the one we trained before
     conditioning_key: crossattn
     monitor: val/loss_simple_ema
     scale_factor: 0.18215

--- a/configs/v2-inference-v.yaml
+++ b/configs/v2-inference-v.yaml
@@ -8,11 +8,11 @@ model:
     num_timesteps_cond: 1
     log_every_t: 200
     timesteps: 1000
-    first_stage_key: "jpg"
-    cond_stage_key: "txt"
+    first_stage_key: "image"
+    cond_stage_key: "caption"
     image_size: 64
     channels: 4
-    cond_stage_trainable: false
+    cond_stage_trainable: true
     conditioning_key: crossattn
     monitor: val/loss_simple_ema
     scale_factor: 0.18215

--- a/configs/v2-inference.yaml
+++ b/configs/v2-inference.yaml
@@ -7,11 +7,11 @@ model:
     num_timesteps_cond: 1
     log_every_t: 200
     timesteps: 1000
-    first_stage_key: "jpg"
-    cond_stage_key: "txt"
+    first_stage_key: "image"
+    cond_stage_key: "caption"
     image_size: 64
     channels: 4
-    cond_stage_trainable: false
+    cond_stage_trainable: true
     conditioning_key: crossattn
     monitor: val/loss_simple_ema
     scale_factor: 0.18215


### PR DESCRIPTION
Can we confirm whether or not that these ***improve*** results? 
The following Stable Diffusion repositories have these enabled, and I feel like enabling these are giving me better results on LoRA training. I *have not* tested this with regular Dreambooth, but I would expect the same.
If this is indeed the case, it would probably be smarter to create separate configs for training (the keys with *this* change) and leave the inference before this change.

_[Dreambooth-Stable-Diffusion](https://github.com/XavierXiao/Dreambooth-Stable-Diffusion/blob/main/configs/stable-diffusion/v1-finetune_unfrozen.yaml)
[Custom Diffusion](https://github.com/adobe-research/custom-diffusion/blob/26ba6388235ec7b636e38d8bc368ac7243036ae7/configs/custom-diffusion/finetune.yaml#L92)
[textual_inversion ](https://github.com/rinongal/textual_inversion/blob/main/configs/stable-diffusion/v1-finetune_unfrozen.yaml)_

Edit:
I'm confident this solves training. Please try both changing the `yaml` you already have (a model before you read this PR) and creating a new one with the new changes. This can help us pinpoint the issue.

If you already have a checkpoint, go to your `configs/dreambooth/your_model_folder/your_model.yaml` and make sure that your `first_stage_key`, `cond_stage_key`, and `cond_stage_trainable` all match the below. Otherwise, change the configs https://github.com/d8ahazard/sd_dreambooth_extension/pull/757/commits/001836d1b482a65940a794bff5ee09f55e4487e6 to match the below and create a new model.

```yaml
model:
  base_learning_rate: 1.0e-04
  target: ldm.models.diffusion.ddpm.LatentDiffusion
  params:
    linear_start: 0.00085
    linear_end: 0.0120
    num_timesteps_cond: 1
    log_every_t: 200
    timesteps: 1000
    first_stage_key: "image"
    cond_stage_key: "caption"
    image_size: 64
    channels: 4
    cond_stage_trainable: true   # Note: different from the one we trained before
    conditioning_key: crossattn
    monitor: val/loss_simple_ema
    scale_factor: 0.18215
```