### PR TITLE
LoRA Rank info and increase maximum settable rank in UI.

### DIFF
--- a/javascript/dreambooth.js
+++ b/javascript/dreambooth.js
@@ -200,7 +200,7 @@ let db_titles = {
     "Load Settings": "Load last saved training parameters for the model.",
     "Log Memory": "Log the current GPU memory usage.",
     "Lora Model": "The Lora model to load for continued fine-tuning or checkpoint generation.",
-    "Lora Rank": "The rank of LoRA models. A low rank stores less information (~2MB file), and a higher rank stores more information (~100MB file). Default is 4 (~4MB file). Choose based on your dataset and complexity before training."
+    "Lora Rank": "The rank of LoRA models. A low rank stores less information (~2MB file), and a higher rank stores more information (~100MB file). Default is 4 (~4MB file) with good results. Set based on your dataset and complexity before training [Advanced Usage]."
     "Lora UNET Learning Rate": "The learning rate at which to train lora unet. Regular learning rate is ignored.",
     "Lora Text Learning Rate": "The learning rate at which to train lora text encoder. Regular learning rate is ignored.",
     "Lora Text Weight": "What percentage of the lora weights should be applied to the text encoder when creating a checkpoint.",

--- a/javascript/dreambooth.js
+++ b/javascript/dreambooth.js
@@ -200,6 +200,7 @@ let db_titles = {
     "Load Settings": "Load last saved training parameters for the model.",
     "Log Memory": "Log the current GPU memory usage.",
     "Lora Model": "The Lora model to load for continued fine-tuning or checkpoint generation.",
+    "Lora Rank": "The rank of LoRA models. A low rank stores less information (~2MB file), and a higher rank stores more information (~100MB file). Default is 4 (~4MB file). Choose based on your dataset and complexity before training."
     "Lora UNET Learning Rate": "The learning rate at which to train lora unet. Regular learning rate is ignored.",
     "Lora Text Learning Rate": "The learning rate at which to train lora text encoder. Regular learning rate is ignored.",
     "Lora Text Weight": "What percentage of the lora weights should be applied to the text encoder when creating a checkpoint.",

--- a/javascript/dreambooth.js
+++ b/javascript/dreambooth.js
@@ -200,7 +200,7 @@ let db_titles = {
     "Load Settings": "Load last saved training parameters for the model.",
     "Log Memory": "Log the current GPU memory usage.",
     "Lora Model": "The Lora model to load for continued fine-tuning or checkpoint generation.",
-    "Lora Rank": "The rank of LoRA models. A low rank stores less information (~2MB file), and a higher rank stores more information (~100MB file). Default is 4 (~4MB file) with good results. Set based on your dataset and complexity before training [Advanced Usage]."
+    "Lora Rank": "The rank of LoRA models. A low rank stores less information (~2MB file), and a higher rank stores more information (~60MB file). Default is 4 (~4MB file) with good results. Set based on your dataset and complexity before training [Advanced Usage]."
     "Lora UNET Learning Rate": "The learning rate at which to train lora unet. Regular learning rate is ignored.",
     "Lora Text Learning Rate": "The learning rate at which to train lora text encoder. Regular learning rate is ignored.",
     "Lora Text Weight": "What percentage of the lora weights should be applied to the text encoder when creating a checkpoint.",

--- a/scripts/api.py
+++ b/scripts/api.py
@@ -469,7 +469,7 @@ def dreambooth_api(_: gr.Blocks, app: FastAPI):
             batch_size: int = Query(1, description="How many images to generate at once."),
             lora_model_path: str = Query("", description="The path to a lora model to use when generating images."),
             lora_rank: int = Query(1,
-                                       description="LORA rank when training, or something.."),
+                                       description="The rank of LoRA models (the amount of data to retain in the LoRA file after training)"),
             lora_weight: float = Query(1.0,
                                        description="The weight of the lora unet when merging with the base model."),
             lora_txt_weight: float = Query(1.0,

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -378,7 +378,7 @@ def on_ui_tabs():
                         db_save_ckpt_cancel = gr.Checkbox(label="Generate a .ckpt file when training is canceled.")
                     with gr.Column(visible=False) as lora_save_col:
                         gr.HTML("Lora")
-                        db_lora_rank = gr.Slider(label="Lora Rank", value=4, minimum=1, maximum=10, step=1)
+                        db_lora_rank = gr.Slider(label="Lora Rank", value=4, minimum=1, maximum=100, step=1)
                         db_lora_weight = gr.Slider(label="Lora Weight", value=1, minimum=0.1, maximum=1, step=0.1)
                         db_lora_txt_weight = gr.Slider(label="Lora Text Weight", value=1, minimum=0.1, maximum=1,
                                                        step=0.1)


### PR DESCRIPTION
With larger datasets, increasing this seems to yield better results if you're willing to have larger files, especially with the latest `.yaml` changes.
 
If you've ever used hypernetworks in the webui, the resulting file at maximum is similar, but more information is retained if you have a very complex dataset with many images.

This is a great alternative to PTI which will lead to great results at the default settings, but it's not implemented yet.

More information can be found here https://github.com/cloneofsimo/lora/discussions/37 .