### PR TITLE
Fix tensorflow requirement macosx M1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,8 @@ fastapi==0.87.0
 ftfy==6.1.1
 modelcards==0.1.6
 tensorboard==2.11.0
-tensorflow==2.11.0
+tensorflow==2.11.0; sys_platform != 'darwin'
+tensorflow-macos==2.11.0; sys_platform == 'darwin'
 tqdm==4.64.1
 transformers==4.25.1
 discord-webhook==1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,8 +6,8 @@ fastapi==0.87.0
 ftfy==6.1.1
 modelcards==0.1.6
 tensorboard==2.11.0
-tensorflow==2.11.0; sys_platform != 'darwin'
-tensorflow-macos==2.11.0; sys_platform == 'darwin'
+tensorflow==2.11.0; sys_platform != 'darwin' or platform_machine != 'arm64'
+tensorflow-macos==2.11.0; sys_platform == 'darwin' and platform_machine == 'arm64'
 tqdm==4.64.1
 transformers==4.25.1
 discord-webhook==1.0.0


### PR DESCRIPTION
Installing on an M1 I got `No module named tensorflow` errors (see #751).
With this change we can install the desired requirements on all supported platforms.

thanks