### PR TITLE
Gradio return Empty DropDownList as blank list

### DIFF
--- a/lora_diffusion/lora.py
+++ b/lora_diffusion/lora.py
@@ -146,6 +146,8 @@ def weight_apply_lora(
 def apply_lora_weights(lora_model, target_unet, target_text_encoder, lora_alpha=1, lora_txt_alpha=1, device=None):
     if device is None:
         device = shared.device
+    if not lora_model:
+        lora_model = ""
     target_unet.requires_grad_(False)
     lora_path = os.path.join(paths.models_path, "lora", lora_model)
     lora_txt = lora_path.replace(".pt", "_txt.pt")


### PR DESCRIPTION
Related to Issue #802

I have identified an issue where an empty DropDownList returns a blank list, which when passed to `os.path.join()` results in a `TypeError: join() argument must be str, bytes, or os.PathLike object, not 'list'`. To prevent this issue from occurring in the future, even with potential changes in Gradio, I have added a check to ensure that the DropDownList is not empty before passing it to `os.path.join()`. This will ensure that the code is immune to future changes in Gradio and prevent the `TypeError` from being raised.

> As an RTX 3080 10GB user, I have found that utilizing LoRA in conjunction with UNET training results in improved performance. By incorporating a LoRA Text Encoder at the first layer and introducing my own prompt, I have observed that the second layer UNET produces better inference.