### PR TITLE
Use patch pipe for generating LoRA samples.

### DIFF
--- a/dreambooth/finetune_utils.py
+++ b/dreambooth/finetune_utils.py
@@ -26,7 +26,7 @@ from extensions.sd_dreambooth_extension.dreambooth.db_config import DreamboothCo
 from extensions.sd_dreambooth_extension.dreambooth.db_shared import status
 from extensions.sd_dreambooth_extension.dreambooth.prompt_data import PromptData
 from extensions.sd_dreambooth_extension.dreambooth.utils import cleanup, get_checkpoint_match, get_images, db_save_image
-from extensions.sd_dreambooth_extension.lora_diffusion.lora import apply_lora_weights
+from extensions.sd_dreambooth_extension.lora_diffusion.lora import patch_pipe
 from modules import shared, devices, sd_models, sd_hijack, prompt_parser, lowvram
 from modules.processing import StableDiffusionProcessingTxt2Img, StableDiffusionProcessing, Processed, \
     get_fixed_seed, create_infotext, decode_first_stage
@@ -463,7 +463,11 @@ class ImageBuilder:
                 if no_safe:
                     db_shared.start_safe_unpickle()
             if config.use_lora and lora_model is not None and lora_model != "":
-                apply_lora_weights(self.image_pipe.unet, self.image_pipe.text_encoder, config, is_ui=True)
+                patch_pipe(
+                    pipe=self.image_pipe,
+                    unet=config.lora_model,
+                    r=config.lora_rank
+                )
         else:
             current_model = sd_models.select_checkpoint()
             new_model_info = get_checkpoint_match(config.src)

--- a/dreambooth/finetune_utils.py
+++ b/dreambooth/finetune_utils.py
@@ -463,17 +463,20 @@ class ImageBuilder:
                 if no_safe:
                     db_shared.start_safe_unpickle()
             if config.use_lora and lora_model is not None and lora_model != "":
+            
+                lora_model_path = os.path.join(db_shared.models_path, "lora", lora_model)
+                lora_txt_path = _text_lora_path_ui(lora_model)
+                
                 patch_pipe(
                     pipe=self.image_pipe,
-                    unet=config.lora_model,
+                    unet_path=lora_model_path,
+                    token="None",
                     r=config.lora_rank
                 )
-                tune_lora_scale(config.lora_model, config.lora_weight)
-
-                lora_txt_path = _text_lora_path_ui(config.lora_model)
                 
+                tune_lora_scale(self.image_pipe.unet, config.lora_weight)
                 if os.path.exists(lora_txt_path):
-                    tune_lora_scale(lora_txt_path, config.lora_txt_weight)
+                    tune_lora_scale(self.image_pipe.text_encoder, config.lora_txt_weight)
 
         else:
             current_model = sd_models.select_checkpoint()

--- a/dreambooth/finetune_utils.py
+++ b/dreambooth/finetune_utils.py
@@ -26,7 +26,7 @@ from extensions.sd_dreambooth_extension.dreambooth.db_config import DreamboothCo
 from extensions.sd_dreambooth_extension.dreambooth.db_shared import status
 from extensions.sd_dreambooth_extension.dreambooth.prompt_data import PromptData
 from extensions.sd_dreambooth_extension.dreambooth.utils import cleanup, get_checkpoint_match, get_images, db_save_image
-from extensions.sd_dreambooth_extension.lora_diffusion.lora import patch_pipe
+from extensions.sd_dreambooth_extension.lora_diffusion.lora import patch_pipe, tune_lora_scale, _text_lora_path_ui
 from modules import shared, devices, sd_models, sd_hijack, prompt_parser, lowvram
 from modules.processing import StableDiffusionProcessingTxt2Img, StableDiffusionProcessing, Processed, \
     get_fixed_seed, create_infotext, decode_first_stage
@@ -468,6 +468,13 @@ class ImageBuilder:
                     unet=config.lora_model,
                     r=config.lora_rank
                 )
+                tune_lora_scale(config.lora_model, config.lora_weight)
+
+                lora_txt_path = _text_lora_path_ui(config.lora_model)
+                
+                if os.path.exists(lora_txt_path):
+                    tune_lora_scale(lora_txt_path, config.lora_txt_weight)
+
         else:
             current_model = sd_models.select_checkpoint()
             new_model_info = get_checkpoint_match(config.src)


### PR DESCRIPTION
Changes to the `patch_pipe` function to generate image samples when using LoRA weights.
The custom `apply_lora_weights` functions are no longer needed.