### PR TITLE
I had enough with Gradio mischief

### DIFF
--- a/dreambooth/diff_to_sd.py
+++ b/dreambooth/diff_to_sd.py
@@ -380,7 +380,8 @@ def compile_checkpoint(model_name: str, lora_path: str=None, reload_models: bool
 
     try:
         printi("Converting unet...", log=log)
-
+        if isinstance(lora_path, list) and len(lora_path) == 0:
+            lora_path = ""
         if lora_path is not None and lora_path != "":
             loaded_pipeline = DiffusionPipeline.from_pretrained(model_path).to("cpu")
             lora_diffusers = config.pretrained_model_name_or_path + "_lora"


### PR DESCRIPTION
Same TypeError as issue #804,

Step I do:
1. Select `Model`
2. Load Settings
3. Save Settings
4. Generate Ckpt

```
Exception compiling checkpoint: stat: path should be string, bytes, os.PathLike or integer, not list
Traceback (most recent call last):
  File "E:\stable-diffusion-webui\extensions\sd_dreambooth_extension\dreambooth\diff_to_sd.py", line 388, in compile_checkpoint
    if not os.path.exists(lora_path):
  File "C:\Program Files\Python310\lib\genericpath.py", line 19, in exists
    os.stat(path)
TypeError: stat: path should be string, bytes, os.PathLike or integer, not list
```

Inactive DropDownList will return as Empty List, this fix should check Data Type and Length, should be immune to Gradio mischief update