### PR TITLE
[dev] Implement strict tokens for captions

### DIFF
--- a/dreambooth/db_config.py
+++ b/dreambooth/db_config.py
@@ -63,6 +63,7 @@ class DreamboothConfig(BaseModel):
     model_path: str = ""
     num_train_epochs: int = 100
     pad_tokens: bool = True
+    strict_tokens: bool = False
     pretrained_model_name_or_path: str = ""
     pretrained_vae_name_or_path: str = ""
     prior_loss_scale: bool = False

--- a/dreambooth/finetune_utils.py
+++ b/dreambooth/finetune_utils.py
@@ -1054,14 +1054,14 @@ def build_strict_tokens(
     ):
 
     caption_list = []
-    caption_split = re.split(r'\s+|[,;.!?]\s*', caption)
+    caption_split = re.split(r'[,;.!?]', caption)
 
     for cap in caption_split:
         words_with_special_token = []
         split_cap = cap.split(" ")
         
         for sc in split_cap:
-            words_with_special_token.append(f"{sc}</w>")
+            if sc: words_with_special_token.append(f"{sc}</w>")
             
         new_cap = ' '.join(words_with_special_token)
         caption_list.append(f"{tenc_start_token}{new_cap}{tenc_start_token}")

--- a/dreambooth/finetune_utils.py
+++ b/dreambooth/finetune_utils.py
@@ -1054,7 +1054,7 @@ def build_strict_tokens(
     ):
 
     caption_list = []
-    caption_split = re.split(r'[,;.!?]', caption)
+    caption_split = re.split(r'[,;.!?]\s', caption)
 
     for cap in caption_split:
         words_with_special_token = []
@@ -1064,7 +1064,7 @@ def build_strict_tokens(
             if sc: words_with_special_token.append(f"{sc}</w>")
             
         new_cap = ' '.join(words_with_special_token)
-        caption_list.append(f"{tenc_start_token}{new_cap}{tenc_start_token}")
+        caption_list.append(f"{tenc_start_token}{new_cap}{tenc_end_token}")
         
     special_caption = ', '.join(caption_list)
 

--- a/dreambooth/finetuning_dataset.py
+++ b/dreambooth/finetuning_dataset.py
@@ -139,7 +139,7 @@ class DbDataset(torch.utils.data.Dataset):
 
     def cache_caption(self, image_path, caption):
         input_ids = None
-        auto_add_special_tokens = False if args.strict_tokens else True
+        auto_add_special_tokens = False if self.strict_tokens else True
 
         if self.tokenizer is not None and image_path not in self.caption_cache:
             if strict_tokens:

--- a/dreambooth/finetuning_dataset.py
+++ b/dreambooth/finetuning_dataset.py
@@ -139,15 +139,19 @@ class DbDataset(torch.utils.data.Dataset):
 
     def cache_caption(self, image_path, caption):
         input_ids = None
+        auto_add_special_tokens = False if args.strict_tokens else True
+
         if self.tokenizer is not None and image_path not in self.caption_cache:
             if strict_tokens:
                 caption = strict_tokens(caption, self.tokenizer.bos_token, self.tokenizer.eos_token)
             if self.not_pad_tokens:
                 input_ids = self.tokenizer(caption, padding=True, truncation=True,
-                                           return_tensors="pt").input_ids
+                                            add_special_tokens=auto_add_special_tokens,
+                                            return_tensors="pt").input_ids
             else:
                 input_ids = self.tokenizer(caption, padding='max_length', truncation=True,
-                                           return_tensors='pt').input_ids
+                                            add_special_tokens=auto_add_special_tokens,
+                                            return_tensors='pt').input_ids
         self.caption_cache[image_path] = input_ids
 
     def make_buckets_with_caching(self, vae, min_size):

--- a/dreambooth/finetuning_dataset.py
+++ b/dreambooth/finetuning_dataset.py
@@ -142,8 +142,8 @@ class DbDataset(torch.utils.data.Dataset):
         auto_add_special_tokens = False if self.strict_tokens else True
 
         if self.tokenizer is not None and image_path not in self.caption_cache:
-            if strict_tokens:
-                caption = strict_tokens(caption, self.tokenizer.bos_token, self.tokenizer.eos_token)
+            if self.strict_tokens:
+                caption = build_strict_tokens(caption, self.tokenizer.bos_token, self.tokenizer.eos_token)
             if self.not_pad_tokens:
                 input_ids = self.tokenizer(caption, padding=True, truncation=True,
                                             add_special_tokens=auto_add_special_tokens,

--- a/javascript/dreambooth.js
+++ b/javascript/dreambooth.js
@@ -218,6 +218,7 @@ let db_titles = {
     "Number of Hard Resets": "Number of hard resets of the lr in cosine_with_restarts scheduler.",
     "Number of Samples to Generate": "How many samples to generate per subject.",
     "Pad Tokens": "Pad the input images token length to this amount. You probably want to do this.",
+    "Strict Tokens": "Parses instance prompts separated by the following characters [,;.!?], and prevents breaking up tokens when using the tokenizer. Useful if you have prompts separated by a lot of tags."
     "Pause After N Epochs": "Number of epochs after which training will be paused for the specified time. Useful if you want to give your GPU a rest.",
     "Performance Wizard (WIP)": "Attempt to automatically set training parameters based on total VRAM. Still under development.",
     "Polynomial Power": "Power factor of the polynomial scheduler.",

--- a/javascript/dreambooth.js
+++ b/javascript/dreambooth.js
@@ -218,7 +218,7 @@ let db_titles = {
     "Number of Hard Resets": "Number of hard resets of the lr in cosine_with_restarts scheduler.",
     "Number of Samples to Generate": "How many samples to generate per subject.",
     "Pad Tokens": "Pad the input images token length to this amount. You probably want to do this.",
-    "Strict Tokens": "Parses instance prompts separated by the following characters [,;.!?], and prevents breaking up tokens when using the tokenizer. Useful if you have prompts separated by a lot of tags."
+    "Strict Tokens": "Parses instance prompts separated by the following characters [,;.!?], and prevents breaking up tokens when using the tokenizer. Useful if you have prompts separated by a lot of tags.",
     "Pause After N Epochs": "Number of epochs after which training will be paused for the specified time. Useful if you want to give your GPU a rest.",
     "Performance Wizard (WIP)": "Attempt to automatically set training parameters based on total VRAM. Still under development.",
     "Polynomial Power": "Power factor of the polynomial scheduler.",

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -328,6 +328,7 @@ def on_ui_tabs():
                                     db_clip_skip = gr.Slider(label="Clip Skip", value=1, minimum=1, maximum=12, step=1)
                                     db_adamw_weight_decay = gr.Slider(label="AdamW Weight Decay", minimum=0, maximum=1, step=1e-7, value=1e-2, visible=True)
                                     db_pad_tokens = gr.Checkbox(label="Pad Tokens", value=True)
+                                    db_strict_tokens = gr.Checkbox(label="Strict Tokens", value=False)
                                     db_shuffle_tags = gr.Checkbox(label="Shuffle Tags", value=True)
                                     db_max_token_length = gr.Slider(label="Max Token Length", minimum=75, maximum=300,
                                                                     step=75)
@@ -580,6 +581,7 @@ def on_ui_tabs():
             db_model_path,
             db_num_train_epochs,
             db_pad_tokens,
+            db_strict_tokens,
             db_pretrained_vae_name_or_path,
             db_prior_loss_scale,
             db_prior_loss_target,


### PR DESCRIPTION
A feature that utilizes the tokenizer's features in order to better parse prompts with context.

Let's say you have a prompt like this: `A cool machine robot with steampunk features, outside on the moon, stars in the background, glowing tron like features, epic, two arms, jetpack, gears on back`

The CLIP tokenizer will parse this prompt and handle the punctuation, but sometimes it may not be what you want. It may break up "steampunk" into "st eam punk", and so on.

What this feature does is use the special tokens from the tokenizer to customize these behaviors. It can help when you have prompt dense tags with a bunch of different features. So now you will have something like this with the functionality of this PR.

`<|startoftext|>A</w> cool</w>  machine</w>  robot</w>  with</w>  steampunk</w>  features</w><|endoftext|> , <|startoftext|>outside</w>...`

These are features read by the tokenizer, but *not* included in the prompt. It tells the tokenizer what are full words, as well as what the beginning and end of sentences should look like.

`bos_token`: <|startoftext|> (Beginning of sentence)
`eos_token`: <|endoftext|> (End of sentence)
`</w>`: A word. 