### PR TITLE
workaround for pipeline problem on Apple Silicon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ docs/_build/
 
 # PyBuilder
 target/
+.DS_Store

--- a/dreambooth/finetune_utils.py
+++ b/dreambooth/finetune_utils.py
@@ -538,18 +538,32 @@ class ImageBuilder:
             shared.total_tqdm = auto_tqdm
             output = processed
         else:
-            with self.accelerator.autocast(), torch.inference_mode():
-                if seed is None or seed == '' or seed == -1:
-                    seed = int(random.randrange(21474836147))
-                g_cuda = torch.Generator(device=self.accelerator.device).manual_seed(seed)
-                output = self.image_pipe(
-                    positive_prompts,
-                    num_inference_steps=steps,
-                    guidance_scale=scale,
-                    height=height,
-                    width=width,
-                    generator=g_cuda,
-                    negative_prompt=negative_prompts).images
+            if self.accelerator.device == torch.device('mps'):
+                with self.accelerator.autocast():
+                    if seed is None or seed == '' or seed == -1:
+                        seed = int(random.randrange(21474836147))
+                    g_cuda = torch.Generator(device='cpu').manual_seed(seed)
+                    output = self.image_pipe(
+                        positive_prompts,
+                        num_inference_steps=steps,
+                        guidance_scale=scale,
+                        height=height,
+                        width=width,
+                        generator=g_cuda,
+                        negative_prompt=negative_prompts).images
+            else:
+                with self.accelerator.autocast(), torch.inference_mode():
+                    if seed is None or seed == '' or seed == -1:
+                        seed = int(random.randrange(21474836147))
+                    g_cuda = torch.Generator(device=self.accelerator.device).manual_seed(seed)
+                    output = self.image_pipe(
+                        positive_prompts,
+                        num_inference_steps=steps,
+                        guidance_scale=scale,
+                        height=height,
+                        width=width,
+                        generator=g_cuda,
+                        negative_prompt=negative_prompts).images
 
         return output
 

--- a/dreambooth/train_dreambooth.py
+++ b/dreambooth/train_dreambooth.py
@@ -710,47 +710,90 @@ def main(args: DreamboothConfig, use_txt2img: bool = True) -> TrainResult:
                             s_pipeline.set_progress_bar_config(disable=True)
                             sample_dir = os.path.join(save_dir, "samples")
                             os.makedirs(sample_dir, exist_ok=True)
-                            with accelerator.autocast(), torch.inference_mode():
-                                sd = SampleDataset(args)
-                                prompts = sd.get_prompts()
-                                concepts = args.concepts()
-                                if args.sanity_prompt != "" and args.sanity_prompt is not None:
-                                    epd = PromptData()
-                                    epd.prompt = args.sanity_prompt
-                                    epd.seed = args.sanity_seed
-                                    epd.negative_prompt = concepts[0].save_sample_negative_prompt
-                                    extra = SampleData(args.sanity_prompt, concept=concepts[0])
-                                    extra.seed = args.sanity_seed
-                                    prompts.append(extra)
-                                pbar.set_description("Generating Samples")
-                                pbar.reset(len(prompts) + 2)
-                                ci = 0
-                                for c in prompts:
-                                    c.out_dir = os.path.join(args.model_dir, "samples")
-                                    c.resolution = (args.resolution, args.resolution)
-                                    seed = int(c.seed)
-                                    if seed is None or seed == '' or seed == -1:
-                                        seed = int(random.randrange(21474836147))
-                                    c.seed = seed
-                                    g_cuda = torch.Generator(device=accelerator.device).manual_seed(seed)
-                                    s_image = s_pipeline(c.prompt, num_inference_steps=c.steps,
-                                                         guidance_scale=c.scale,
-                                                         negative_prompt=c.negative_prompt,
-                                                         height=args.resolution,
-                                                         width=args.resolution,
-                                                         generator=g_cuda).images[0]
+                            if accelerator.device == torch.device('mps'):
+                                with accelerator.autocast():
+                                        sd = SampleDataset(args)
+                                        prompts = sd.get_prompts()
+                                        concepts = args.concepts()
+                                        if args.sanity_prompt != "" and args.sanity_prompt is not None:
+                                            epd = PromptData()
+                                            epd.prompt = args.sanity_prompt
+                                            epd.seed = args.sanity_seed
+                                            epd.negative_prompt = concepts[0].save_sample_negative_prompt
+                                            extra = SampleData(args.sanity_prompt, concept=concepts[0])
+                                            extra.seed = args.sanity_seed
+                                            prompts.append(extra)
+                                        pbar.set_description("Generating Samples")
+                                        pbar.reset(len(prompts) + 2)
+                                        ci = 0
+                                        for c in prompts:
+                                            c.out_dir = os.path.join(args.model_dir, "samples")
+                                            c.resolution = (args.resolution, args.resolution)
+                                            seed = int(c.seed)
+                                            if seed is None or seed == '' or seed == -1:
+                                                seed = int(random.randrange(21474836147))
+                                            c.seed = seed
+                                            g_cuda = torch.Generator(device='cpu').manual_seed(seed)
+                                            s_image = s_pipeline(c.prompt, num_inference_steps=c.steps,
+                                                                 guidance_scale=c.scale,
+                                                                 negative_prompt=c.negative_prompt,
+                                                                 height=args.resolution,
+                                                                 width=args.resolution,
+                                                                 generator=g_cuda).images[0]
 
-                                    sample_prompts.append(c.prompt)
-                                    image_name = db_save_image(s_image,c, seed, custom_name=f"sample_{args.revision}-{ci}")
-                                    samples.append(image_name)
-                                    pbar.update()
-                                    ci += 1
-                                for sample in samples:
-                                    last_samples.append(sample)
-                                for prompt in sample_prompts:
-                                    last_prompts.append(prompt)
-                                del samples
-                                del prompts
+                                            sample_prompts.append(c.prompt)
+                                            image_name = db_save_image(s_image,c, seed, custom_name=f"sample_{args.revision}-{ci}")
+                                            samples.append(image_name)
+                                            pbar.update()
+                                            ci += 1
+                                        for sample in samples:
+                                            last_samples.append(sample)
+                                        for prompt in sample_prompts:
+                                            last_prompts.append(prompt)
+                                        del samples
+                                        del prompts
+                            else:
+                                with accelerator.autocast(), torch.inference_mode():
+                                    sd = SampleDataset(args)
+                                    prompts = sd.get_prompts()
+                                    concepts = args.concepts()
+                                    if args.sanity_prompt != "" and args.sanity_prompt is not None:
+                                        epd = PromptData()
+                                        epd.prompt = args.sanity_prompt
+                                        epd.seed = args.sanity_seed
+                                        epd.negative_prompt = concepts[0].save_sample_negative_prompt
+                                        extra = SampleData(args.sanity_prompt, concept=concepts[0])
+                                        extra.seed = args.sanity_seed
+                                        prompts.append(extra)
+                                    pbar.set_description("Generating Samples")
+                                    pbar.reset(len(prompts) + 2)
+                                    ci = 0
+                                    for c in prompts:
+                                        c.out_dir = os.path.join(args.model_dir, "samples")
+                                        c.resolution = (args.resolution, args.resolution)
+                                        seed = int(c.seed)
+                                        if seed is None or seed == '' or seed == -1:
+                                            seed = int(random.randrange(21474836147))
+                                        c.seed = seed
+                                        g_cuda = torch.Generator(device=accelerator.device).manual_seed(seed)
+                                        s_image = s_pipeline(c.prompt, num_inference_steps=c.steps,
+                                                             guidance_scale=c.scale,
+                                                             negative_prompt=c.negative_prompt,
+                                                             height=args.resolution,
+                                                             width=args.resolution,
+                                                             generator=g_cuda).images[0]
+
+                                        sample_prompts.append(c.prompt)
+                                        image_name = db_save_image(s_image,c, seed, custom_name=f"sample_{args.revision}-{ci}")
+                                        samples.append(image_name)
+                                        pbar.update()
+                                        ci += 1
+                                    for sample in samples:
+                                        last_samples.append(sample)
+                                    for prompt in sample_prompts:
+                                        last_prompts.append(prompt)
+                                    del samples
+                                    del prompts
 
                         except Exception as em:
                             print(f"Exception saving sample: {em}")

--- a/dreambooth/train_dreambooth.py
+++ b/dreambooth/train_dreambooth.py
@@ -751,7 +751,7 @@ def main(args: DreamboothConfig, use_txt2img: bool = True) -> TrainResult:
                                         for prompt in sample_prompts:
                                             last_prompts.append(prompt)
                                         del samples
-                                        del prompts
+                                        del prompt
                             else:
                                 with accelerator.autocast(), torch.inference_mode():
                                     sd = SampleDataset(args)


### PR DESCRIPTION
Workaround for pipeline image generation with Apple Silicon. Moved torch.Generator, which is not supported on MPS, to cpu.
Removed inference_mode(). When enabled, it generates black images. No idea why.
It requires torch>=1.13. For training to work correctly, it requires nightly build.