### PR TITLE
Fix a reference exception with out_file

### DIFF
--- a/dreambooth/train_dreambooth.py
+++ b/dreambooth/train_dreambooth.py
@@ -646,8 +646,8 @@ def main(args: DreamboothConfig, use_txt2img: bool = True) -> TrainResult:
                         pbar.reset(4)
                         pbar.update()
                         try:
+                            out_file = None
                             if not args.use_lora:
-                                out_file = None
                                 if save_snapshot:
                                     pbar.set_description("Saving Snapshot")
                                     status.textinfo = f"Saving snapshot at step {args.revision}..."


### PR DESCRIPTION
The declaration location of the variable out_file was causing an exception at line 690. I don't think this will have any unexpected issues, but double check.

## Describe your changes


## Issue ticket number and link (if applicable)


## Checklist before requesting a review
- [ ] This is based on the /dev branch (Or a fork of it)
- [ ] This was created or at least validated using a proper IDE
- [ ] I have tested this code and validated any modified functions
- [ ] I have added the appropriate documentation and hint strings if adding or changing a user-facing feature
