### PR TITLE
Fix resuming training from LoRA weights failing with an exception

### DIFF
--- a/lora_diffusion/lora.py
+++ b/lora_diffusion/lora.py
@@ -246,8 +246,8 @@ def inject_trainable_lora(
         require_grad_params.append(_module._modules[name].lora_down.parameters())
 
         if loras is not None:
-            _module._modules[name].lora_up.weight = loras.pop(0)
-            _module._modules[name].lora_down.weight = loras.pop(0)
+            _module._modules[name].lora_up.weight = nn.Parameter(loras.pop(0))
+            _module._modules[name].lora_down.weight = nn.Parameter(loras.pop(0))
 
         _module._modules[name].lora_up.weight.requires_grad = True
         _module._modules[name].lora_down.weight.requires_grad = True
@@ -320,8 +320,8 @@ def inject_trainable_lora_extended(
         require_grad_params.append(_module._modules[name].lora_down.parameters())
 
         if loras != None:
-            _module._modules[name].lora_up.weight = loras.pop(0)
-            _module._modules[name].lora_down.weight = loras.pop(0)
+            _module._modules[name].lora_up.weight = nn.Parameter(loras.pop(0))
+            _module._modules[name].lora_down.weight = nn.Parameter(loras.pop(0))
 
         _module._modules[name].lora_up.weight.requires_grad = True
         _module._modules[name].lora_down.weight.requires_grad = True


### PR DESCRIPTION
## Describe your changes

This is a fix for #957 where training cannot be resumed from LoRA weights due to the exception:

```
TypeError: cannot assign 'torch.FloatTensor' as parameter 'weight' (torch.nn.Parameter or None expected)
```

 To resolve it, I changed

```python
if loras is not None:
    _module._modules[name].lora_up.weight = loras.pop(0)
    _module._modules[name].lora_down.weight = loras.pop(0)
```

to

```python
if loras is not None:
    _module._modules[name].lora_up.weight = nn.Parameter(loras.pop(0))
    _module._modules[name].lora_down.weight = nn.Parameter(loras.pop(0))
```

## Issue ticket number and link (if applicable)

Issue is #957.

## Checklist before requesting a review
- [x] This is based on the /dev branch (Or a fork of it)
- [x] This was created or at least validated using a proper IDE
- [x] I have tested this code and validated any modified functions
- [x] I have added the appropriate documentation and hint strings if adding or changing a user-facing feature
