### PR TITLE
Implement option to save extra_networks lora.py

### DIFF
--- a/dreambooth/dataclasses/db_config.py
+++ b/dreambooth/dataclasses/db_config.py
@@ -94,6 +94,7 @@ class DreamboothConfig(BaseModel):
     save_lora_after: bool = True
     save_lora_cancel: bool = False
     save_lora_during: bool = True
+    save_lora_for_extra_net: bool = True
     save_preview_every: int = 5
     save_safetensors: bool = True
     save_state_after: bool = False

--- a/dreambooth/dataclasses/db_config.py
+++ b/dreambooth/dataclasses/db_config.py
@@ -44,7 +44,6 @@ class DreamboothConfig(BaseModel):
     gradient_checkpointing: bool = True
     gradient_set_to_none: bool = True
     graph_smoothing: int = 50
-    half_lora: bool = False
     half_model: bool = False
     train_unfrozen: bool = True
     has_ema: bool = False

--- a/dreambooth/diff_to_sd.py
+++ b/dreambooth/diff_to_sd.py
@@ -553,9 +553,7 @@ def apply_lora(config: DreamboothConfig, model: nn.Module, lora_file_name: str, 
     lora_rev = None
     if lora_file_name is not None and lora_file_name != "":
         if not os.path.exists(lora_file_name):
-            lora_dir = os.path.join(config.model_dir, "loras")
-            lora_file_name = os.path.join(lora_dir, "lora", lora_file_name)
-
+            lora_file_name = os.path.join(config.model_dir, "loras", lora_file_name)
         if os.path.exists(lora_file_name):
             lora_rev = lora_file_name.split("_")[-1].replace(".pt", "")
             printi(f"Loading lora from {lora_file_name}", log=True)

--- a/dreambooth/diff_to_sd.py
+++ b/dreambooth/diff_to_sd.py
@@ -556,7 +556,7 @@ def apply_lora(model: nn.Module, loras: str, rank: int, weight: float, device: s
     if loras is not None and loras != "":
         if not os.path.exists(loras):
             try:
-                cmd_lora_models_path = shared.lora_models_path
+                cmd_lora_models_path = shared.db_lora_models_path
             except:
                 cmd_lora_models_path = None
             model_dir = os.path.dirname(cmd_lora_models_path) if cmd_lora_models_path else shared.models_path

--- a/dreambooth/shared.py
+++ b/dreambooth/shared.py
@@ -16,7 +16,7 @@ from packaging import version
 def load_auto_settings():
     global models_path, script_path, ckpt_dir, device_id, disable_safe_unpickle, dataset_filename_word_regex, \
         dataset_filename_join_string, show_progress_every_n_steps, parallel_processing_allowed, state, ckptfix, medvram, \
-        lowvram, dreambooth_models_path, lora_models_path, CLIP_stop_at_last_layers, profile_db, debug, config, device, \
+        lowvram, dreambooth_models_path, ui_lora_models_path, db_lora_models_path, CLIP_stop_at_last_layers, profile_db, debug, config, device, \
         force_cpu, embeddings_dir, sd_model
     try:
         import modules.script_callbacks
@@ -51,7 +51,7 @@ def load_auto_settings():
 
         try:
             dreambooth_models_path = ws.cmd_opts.dreambooth_models_path or dreambooth_models_path
-            lora_models_path = ws.cmd_opts.lora_models_path or lora_models_path
+            ui_lora_models_path = ws.cmd_opts.lora_models_path or ui_lora_models_path
             embeddings_dir = ws.cmd_opts.embeddings_dir or embeddings_dir
         except:
             pass
@@ -293,7 +293,8 @@ models_path = os.path.join(script_path, "models")
 embeddings_dir = os.path.join(script_path, "embeddings")
 dreambooth_models_path = os.path.join(models_path, "dreambooth")
 ckpt_dir = os.path.join(models_path, "Stable-diffusion")
-lora_models_path = os.path.join(models_path, "lora")
+ui_lora_models_path = os.path.join(models_path, "lora")
+db_lora_models_path = os.path.join(models_path, "db_lora")
 db_model_config = None
 data_path = os.path.join(script_path, ".cache")
 show_progress_every_n_steps = 10

--- a/dreambooth/shared.py
+++ b/dreambooth/shared.py
@@ -16,7 +16,7 @@ from packaging import version
 def load_auto_settings():
     global models_path, script_path, ckpt_dir, device_id, disable_safe_unpickle, dataset_filename_word_regex, \
         dataset_filename_join_string, show_progress_every_n_steps, parallel_processing_allowed, state, ckptfix, medvram, \
-        lowvram, dreambooth_models_path, ui_lora_models_path, db_lora_models_path, CLIP_stop_at_last_layers, profile_db, debug, config, device, \
+        lowvram, dreambooth_models_path, ui_lora_models_path, CLIP_stop_at_last_layers, profile_db, debug, config, device, \
         force_cpu, embeddings_dir, sd_model
     try:
         import modules.script_callbacks
@@ -294,7 +294,6 @@ embeddings_dir = os.path.join(script_path, "embeddings")
 dreambooth_models_path = os.path.join(models_path, "dreambooth")
 ckpt_dir = os.path.join(models_path, "Stable-diffusion")
 ui_lora_models_path = os.path.join(models_path, "lora")
-db_lora_models_path = os.path.join(models_path, "db_lora")
 db_model_config = None
 data_path = os.path.join(script_path, ".cache")
 show_progress_every_n_steps = 10

--- a/dreambooth/train_dreambooth.py
+++ b/dreambooth/train_dreambooth.py
@@ -331,7 +331,7 @@ def main(use_txt2img: bool = True) -> TrainResult:
         if args.use_lora:
             unet.requires_grad_(False)
             if args.lora_model_name:
-                lora_path = os.path.join(shared.models_path, "db_lora", args.lora_model_name)
+                lora_path = os.path.join(args.model_dir, "loras", args.lora_model_name)
                 lora_txt = lora_path.replace(".pt", "_txt.pt")
 
                 if not os.path.exists(lora_path) or not os.path.isfile(lora_path):
@@ -718,8 +718,8 @@ def main(use_txt2img: bool = True) -> TrainResult:
                     requires_safety_checker=None
                 )
                 scheduler_class = get_scheduler_class(args.scheduler)
-                s_pipeline.unet = torch2ify(s_pipeline.unet)
                 s_pipeline.enable_attention_slicing()
+                s_pipeline.unet = torch2ify(s_pipeline.unet)
                 xformerify(s_pipeline)
 
                 s_pipeline.scheduler = scheduler_class.from_config(s_pipeline.scheduler.config)

--- a/dreambooth/train_dreambooth.py
+++ b/dreambooth/train_dreambooth.py
@@ -768,8 +768,7 @@ def main(use_txt2img: bool = True) -> TrainResult:
                                     modelmap["text_encoder"] = (s_pipeline.text_encoder, TEXT_ENCODER_DEFAULT_TARGET_REPLACE)
                                     save_lora_weight(s_pipeline.text_encoder,
                                                      out_txt,
-                                                     target_replace_module=TEXT_ENCODER_DEFAULT_TARGET_REPLACE,
-                                                     d_type=d_type)
+                                                     target_replace_module=TEXT_ENCODER_DEFAULT_TARGET_REPLACE)
                                     pbar.update()
                                 # save extra_net
                                 if args.save_lora_for_extra_net:

--- a/dreambooth/train_dreambooth.py
+++ b/dreambooth/train_dreambooth.py
@@ -243,21 +243,12 @@ def main(use_txt2img: bool = True) -> TrainResult:
         vae = create_vae()
         printm("Created vae")
 
-        try:
-            unet = UNet2DConditionModel.from_pretrained(
-                args.pretrained_model_name_or_path,
-                subfolder="unet",
-                revision=args.revision,
-                torch_dtype=torch.float32
-            )
-        except:
-            unet = UNet2DConditionModel.from_pretrained(
-                args.pretrained_model_name_or_path,
-                subfolder="unet",
-                revision=args.revision,
-                torch_dtype=torch.float16
-            )
-            unet = unet.to(dtype=torch.float32)
+        unet = UNet2DConditionModel.from_pretrained(
+            args.pretrained_model_name_or_path,
+            subfolder="unet",
+            revision=args.revision,
+            torch_dtype=torch.float32
+        )
         unet = torch2ify(unet)
 
         # Check that all trainable models are in full precision
@@ -768,8 +759,7 @@ def main(use_txt2img: bool = True) -> TrainResult:
                                 out_file = os.path.join(loras_dir, f"{lora_file_prefix}.pt")
                                 # create pt
                                 tgt_module = get_target_module("module", args.use_lora_extended)
-                                d_type = torch.float16 if args.half_lora else torch.float32
-                                save_lora_weight(s_pipeline.unet, out_file, tgt_module, d_type=d_type)
+                                save_lora_weight(s_pipeline.unet, out_file, tgt_module)
 
                                 modelmap = {"unet": (s_pipeline.unet, tgt_module)}
                                 # save text_encoder

--- a/dreambooth/ui_functions.py
+++ b/dreambooth/ui_functions.py
@@ -600,6 +600,10 @@ def load_model_params(model_name):
         snaps.insert(0, "")
         db_model_snapshots = gr_update(choices=snaps, value=snap_selection)
 
+        loras = get_lora_models(config)
+        loras.insert(0, "")
+        db_lora_models = gr_update(choices=loras)
+
         msg = f"Selected model: '{model_name}'."
         return config.model_dir, \
             config.revision, \
@@ -608,6 +612,7 @@ def load_model_params(model_name):
             "True" if config.has_ema else "False", \
             config.src, \
             db_model_snapshots, \
+            db_lora_models, \
             msg
 
 

--- a/dreambooth/ui_functions.py
+++ b/dreambooth/ui_functions.py
@@ -597,11 +597,9 @@ def load_model_params(model_name):
     else:
         snaps = get_model_snapshots(config)
         snap_selection = config.revision if str(config.revision) in snaps else ""
-        snaps.insert(0, "")
         db_model_snapshots = gr_update(choices=snaps, value=snap_selection)
 
         loras = get_lora_models(config)
-        loras.insert(0, "")
         db_lora_models = gr_update(choices=loras)
 
         msg = f"Selected model: '{model_name}'."

--- a/dreambooth/ui_functions.py
+++ b/dreambooth/ui_functions.py
@@ -30,8 +30,8 @@ try:
     from extensions.sd_dreambooth_extension.dreambooth.utils.image_utils import get_images, db_save_image, \
         make_bucket_resolutions, get_dim, closest_resolution, open_and_trim
     from extensions.sd_dreambooth_extension.dreambooth.utils.model_utils import unload_system_models, \
-        reload_system_models, \
-        get_lora_models, get_checkpoint_match
+    reload_system_models, \
+    get_lora_models, get_checkpoint_match, get_model_snapshots
     from extensions.sd_dreambooth_extension.dreambooth.utils.utils import printm, cleanup
     from extensions.sd_dreambooth_extension.helpers.image_builder import ImageBuilder
     from extensions.sd_dreambooth_extension.helpers.mytqdm import mytqdm
@@ -66,18 +66,6 @@ def gr_update(default=None, **kwargs):
         return gradio.update(visible=True, **kwargs)
     except:
         return kwargs["value"] if "value" in kwargs else default
-
-
-def get_model_snapshot(config: DreamboothConfig):
-    snaps_dir = os.path.join(config.model_dir, "checkpoints")
-    snaps = []
-    if os.path.exists(snaps_dir):
-        for file in os.listdir(snaps_dir):
-            if os.path.isdir(os.path.join(snaps_dir, file)):
-                rev_parts = file.split("-")
-                if rev_parts[0] == "checkpoint" and len(rev_parts) == 2:
-                    snaps.append(rev_parts[1])
-    return snaps
 
 
 def training_wizard_person(model_dir):
@@ -600,25 +588,25 @@ def load_model_params(model_name):
     db_model_snapshots: A gradio dropdown containing the available snapshots for the model
     db_outcome: The result of loading model params
     """
-    data = from_file(model_name)
+    config = from_file(model_name)
     db_model_snapshots = gr_update(choices=[], value="")
-    if data is None:
+    if config is None:
         print("Can't load config!")
         msg = f"Error loading model params: '{model_name}'."
         return "", "", "", "", "", db_model_snapshots, msg
     else:
-        snaps = get_model_snapshot(data)
-        snap_selection = data.revision if str(data.revision) in snaps else ""
+        snaps = get_model_snapshots(config)
+        snap_selection = config.revision if str(config.revision) in snaps else ""
         snaps.insert(0, "")
         db_model_snapshots = gr_update(choices=snaps, value=snap_selection)
 
         msg = f"Selected model: '{model_name}'."
-        return data.model_dir, \
-            data.revision, \
-            data.epoch, \
-            "True" if data.v2 else "False", \
-            "True" if data.has_ema else "False", \
-            data.src, \
+        return config.model_dir, \
+            config.revision, \
+            config.epoch, \
+            "True" if config.v2 else "False", \
+            "True" if config.has_ema else "False", \
+            config.src, \
             db_model_snapshots, \
             msg
 

--- a/dreambooth/utils/model_utils.py
+++ b/dreambooth/utils/model_utils.py
@@ -123,7 +123,7 @@ def get_db_models():
 
 
 def get_lora_models(config: DreamboothConfig = None):
-    output = []
+    output = [""]
     if config is None:
         config = shared.db_model_config
     if config is not None:
@@ -149,7 +149,7 @@ def get_sorted_lora_models(config: DreamboothConfig = None):
 
 
 def get_model_snapshots(config: DreamboothConfig = None):
-    snaps = []
+    snaps = [""]
     if config is None:
         config = shared.db_model_config
     if config is not None:

--- a/dreambooth/utils/model_utils.py
+++ b/dreambooth/utils/model_utils.py
@@ -141,7 +141,7 @@ def get_sorted_lora_models(config: DreamboothConfig = None):
     models = get_lora_models(config)
 
     def get_iteration(name: str):
-        regex = re.compile(r'.*_(\d+)\.(pt|safetensors|ckpt)')
+        regex = re.compile(r'.*_(\d+)\.pt$')
         match = regex.search(name)
         return int(match.group(1)) if match else 0
 

--- a/dreambooth/utils/model_utils.py
+++ b/dreambooth/utils/model_utils.py
@@ -147,7 +147,7 @@ def get_db_models():
 
 
 def get_lora_models():
-    model_dir = shared.lora_models_path
+    model_dir = shared.db_lora_models_path
     out_dir = model_dir
     output = [""]
     if os.path.exists(out_dir):

--- a/dreambooth/utils/model_utils.py
+++ b/dreambooth/utils/model_utils.py
@@ -114,12 +114,6 @@ def list_models():
 os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'
 
 
-def get_iteration(name: str):
-    regex = re.compile(r'.*_(\d+)\.pt')
-    match = regex.search(name)
-    return int(match.group(1)) if match else 0
-
-
 def get_db_models():
     output = [""]
     out_dir = shared.dreambooth_models_path
@@ -145,6 +139,12 @@ def get_lora_models(config: DreamboothConfig = None):
 
 def get_sorted_lora_models(config: DreamboothConfig = None):
     models = get_lora_models(config)
+
+    def get_iteration(name: str):
+        regex = re.compile(r'.*_(\d+)\.(pt|safetensors|ckpt)')
+        match = regex.search(name)
+        return int(match.group(1)) if match else 0
+
     return sorted(models, key=lambda x: get_iteration(x))
 
 
@@ -161,11 +161,6 @@ def get_model_snapshots(config: DreamboothConfig = None):
                     if rev_parts[0] == "checkpoint" and len(rev_parts) == 2:
                         snaps.append(rev_parts[1])
     return snaps
-
-
-def get_sorted_model_snapshots(config: DreamboothConfig = None):
-    models = get_model_snapshots(config)
-    return sorted(models, key=lambda x: get_iteration(x))
 
 
 def unload_system_models():

--- a/dreambooth/utils/model_utils.py
+++ b/dreambooth/utils/model_utils.py
@@ -123,7 +123,7 @@ def get_db_models():
 
 
 def get_lora_models(config: DreamboothConfig = None):
-    output = [""]
+    output = []
     if config is None:
         config = shared.db_model_config
     if config is not None:
@@ -149,7 +149,7 @@ def get_sorted_lora_models(config: DreamboothConfig = None):
 
 
 def get_model_snapshots(config: DreamboothConfig = None):
-    snaps = [""]
+    snaps = []
     if config is None:
         config = shared.db_model_config
     if config is not None:

--- a/javascript/dreambooth.js
+++ b/javascript/dreambooth.js
@@ -347,6 +347,7 @@ let db_titles = {
     "Generate a .ckpt file when saving during training.": "When enabled, a checkpoint will be generated at the specified epoch intervals while training is active. This also controls manual generation using the 'save weights' button while training is active.",
     "Generate a .ckpt file when training completes.": "When enabled, a checkpoint will be generated when training completes successfully.",
     "Generate a .ckpt file when training is cancelled.": "When enabled, a checkpoint will be generated when training is cancelled by the user.",
+    "Generate lora weights Generate lora weights for additional networks.": "When enabled, a lora .safetensors file will be generated in the ui lora model directory that is compatible with additional networks. Not compatible with extended lora.",
     "Generate lora weights when saving during training.": "When enabled, lora .pt files will be generated at each specified epoch interval during training. This also affects whether .pt files will be generated when manually clicking the 'Save Weights' button.",
     "Generate lora weights when training completes.": "When enabled, lora .pt files will be generated when training completes.",
     "Generate lora weights when training is canceled.": "When enabled, lora .pt files will be generated when training is cancelled by the user.",

--- a/javascript/dreambooth.js
+++ b/javascript/dreambooth.js
@@ -448,7 +448,7 @@ onUiUpdate(function () {
     if (cm && cl) {
         if (cl.innerHTML !== "" && modalShown !== true) {
             modalShown = true;
-            cm.classList.add("active");
+            //cm.classList.add("active");
         }
     }
 

--- a/lora_diffusion/extra_networks.py
+++ b/lora_diffusion/extra_networks.py
@@ -1,0 +1,136 @@
+import json
+from safetensors.torch import save_file as safe_save
+from typing import Optional, Set
+import torch.nn as nn
+
+
+try:
+    from extensions.sd_dreambooth_extension.lora_diffusion.lora import DEFAULT_TARGET_REPLACE, LoraInjectedLinear, LoraInjectedConv2d
+except:
+    from dreambooth.lora_diffusion.lora import DEFAULT_TARGET_REPLACE, LoraInjectedLinear, LoraInjectedConv2d  # noqa
+
+
+def _find_modules_with_ancestor(
+    model,
+    ancestor_class: Optional[Set[str]] = None,
+    search_class=None,
+    exclude_children_of=None,
+):
+    """
+    Find all modules of a certain class (or union of classes) that are direct or
+    indirect descendants of other modules of a certain class (or union of classes).
+    Returns all matching modules, along with the parent of those moduless and the
+    names they are referenced by as the full ansestor name.
+    This is a copy of _find_modules_v2 from lora.py. It was copied instead of
+    refactored to keep the implementation in lora.py in sync with cloneofsimo.
+    """
+    # Get the targets we should replace all linears under
+    if exclude_children_of is None:
+        exclude_children_of = [
+            LoraInjectedLinear,
+            LoraInjectedConv2d,
+        ]
+    if search_class is None:
+        search_class = [nn.Linear]
+    if ancestor_class is not None:
+        ancestors = (
+            (name, module)
+            for name, module in model.named_modules()
+            if module.__class__.__name__ in ancestor_class
+        )
+    else:
+        # this, incase you want to naively iterate over all modules.
+        ancestors = [(name, module) for name, module in model.named_modules()]
+
+    # For each target find every linear_class module that isn't a child of a LoraInjectedLinear
+    for anc_name, ancestor in ancestors:
+        for fullname, module in ancestor.named_modules():
+            if any([isinstance(module, _class) for _class in search_class]):
+                # Find the direct parent if this is a descendant, not a child, of target
+                *path, name = fullname.split(".")
+                parent = ancestor
+                while path:
+                    parent = parent.get_submodule(path.pop(0))
+                # Skip this linear if it's a child of a LoraInjectedLinear
+                if exclude_children_of and any(
+                    [isinstance(parent, _class)
+                     for _class in exclude_children_of]
+                ):
+                    continue
+                # Otherwise, yield it
+                yield parent, name, module, fullname, anc_name
+
+
+def get_extra_networks_diffsuers_key(name, child_module, full_child_name):
+    """
+    Computed the diffusers key that is compatible with the extra networks feature in the webui.
+    """
+    if child_module.__class__.__name__ == "LoraInjectedLinear" or child_module.__class__.__name__ == "LoraInjectedConv2d":
+        lora_name = f"{name}.{full_child_name}"
+        lora_name = lora_name.replace('.', '_')
+        return lora_name
+    else:
+        print(f"Unsupported module type {child_module.__class__.__name__}")
+        return None
+
+
+def get_extra_networks_ups_down(model, target_replace_module=None):
+    """
+    Get a list of loras and keys for saving to extra networks.
+    """
+    if target_replace_module is None:
+        target_replace_module = DEFAULT_TARGET_REPLACE
+    loras = []
+
+    for _m, child_name, _child_module, fullname, ancestor_name in _find_modules_with_ancestor(
+        model,
+        target_replace_module,
+        search_class=[LoraInjectedLinear, LoraInjectedConv2d],
+    ):
+        key = get_extra_networks_diffsuers_key(
+            ancestor_name, _child_module, fullname)
+        if key is None:
+            print(f"{ancestor_name}, {child_name} did not converst to key.")
+        loras.append((key, _child_module.lora_up, _child_module.lora_down))
+
+    if len(loras) == 0:
+        raise ValueError("No lora injected.")
+
+    return loras
+
+
+def save_extra_networks(modelmap={}, outpath="./lora.safetensors"):
+    """
+    Saves the Lora from multiple modules in a single safetensor file that is compatible with extra_networks.
+    modelmap is a dictionary of {
+        "module name": (module, target_replace_module)
+    }
+
+    metadata contains a mapping from the keys to the normal lora keys.
+    """
+
+    weights = {}
+    metadata = {}
+    # set some metadata
+    metadata["lora_key_encoding"] = "extra_network_diffusers"
+    for name, (model, target_replace_module) in modelmap.items():
+        metadata[name] = json.dumps(list(target_replace_module))
+        prefix = "lora_unet" if name == "unet" else "lora_te"
+        rank = None
+        for i, (_key, _up, _down) in enumerate(
+            get_extra_networks_ups_down(model, target_replace_module)
+        ):
+            try:
+                rank = getattr(_down, "out_features")
+            except:
+                rank = getattr(_down, "out_channels")
+            weights[f"{prefix}_{_key}.lora_up.weight"] = _up.weight
+            weights[f"{prefix}_{_key}.lora_down.weight"] = _down.weight
+            metadata[f"{name}:{i}:up"] = f"{prefix}_{_key}.lora_up.weight"
+            metadata[f"{name}:{i}:down"] = f"{prefix}_{_key}.lora_down.weight"
+            metadata[f"{name}:{i}:rank"] = str(rank)
+        if rank:
+            metadata[f"{prefix}_rank"] = f"{rank}"
+
+    print(f"Saving weights to {outpath}")
+    safe_save(weights, outpath, metadata)

--- a/lora_diffusion/lora.py
+++ b/lora_diffusion/lora.py
@@ -357,7 +357,7 @@ def save_lora_weight(
         path="./lora.pt",
         target_replace_module=None,
         save_safetensors: bool = False,
-        d_type: dtype = torch.float16
+        d_type: dtype = torch.float32
 ):
     if target_replace_module is None:
         target_replace_module = DEFAULT_TARGET_REPLACE

--- a/postinstall.py
+++ b/postinstall.py
@@ -153,7 +153,7 @@ def actual_install():
                 # Add package name and version tuple to dictionary
                 reqs_dict[package_name] = version_tuple
 
-        checks = ["bitsandbytes", "diffusers", "transformers", "xformers"]
+        checks = ["accelerate", "bitsandbytes", "diffusers", "transformers", "xformers"]
         torch_ver = "1.13.1+cu117"
         torch_vis_ver = "0.14.1+cu117"
         xformers_ver = "0.0.17.dev464"

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,3 @@ tqdm~=4.64.1
 transformers~=4.26.1
 discord-webhook~=1.1.0
 lion-pytorch~=0.0.7
-xformers==0.0.17.dev464

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ tqdm~=4.64.1
 transformers~=4.26.1
 discord-webhook~=1.1.0
 lion-pytorch~=0.0.7
+xformers==0.0.17.dev464

--- a/scripts/api.py
+++ b/scripts/api.py
@@ -597,11 +597,13 @@ def dreambooth_api(_, app: FastAPI):
     @app.get("/dreambooth/models_lora")
     async def get_models_lora(
             api_key: str = Query("", description="If an API key is set, this must be present."),
+            model_name: str = Query(description="The model name to query for lora files."),
     ) -> JSONResponse:
         """
 
         Args:
             api_key: API Key.
+            model_name: The model name to query for lora files.
 
         Returns: A list of LoRA Models.
 
@@ -609,7 +611,12 @@ def dreambooth_api(_, app: FastAPI):
         key_check = check_api_key(api_key)
         if key_check is not None:
             return key_check
-        models = get_lora_models()
+
+        config = from_file(model_name)
+        if model_name and config is None:
+            return JSONResponse("Config not found")
+
+        models = get_lora_models(config)
         return JSONResponse(models)
 
     @app.get("/dreambooth/samples")

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -433,7 +433,6 @@ def on_ui_tabs():
                     with gr.Column():
                         gr.HTML("Checkpoints")
                         db_half_model = gr.Checkbox(label="Half Model", value=False)
-                        db_half_lora = gr.Checkbox(label="Half Lora", value=False)
                         db_use_subdir = gr.Checkbox(label="Save Checkpoint to Subdirectory", value=True)
                         db_save_ckpt_during = gr.Checkbox(label="Generate a .ckpt file when saving during training.")
                         db_save_ckpt_after = gr.Checkbox(label="Generate a .ckpt file when training completes.",
@@ -695,7 +694,6 @@ def on_ui_tabs():
             db_gradient_checkpointing,
             db_gradient_set_to_none,
             db_graph_smoothing,
-            db_half_lora,
             db_half_model,
             db_hflip,
             db_infer_ema,

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -12,7 +12,8 @@ from extensions.sd_dreambooth_extension.dreambooth.ui_functions import performan
     training_wizard, training_wizard_person, load_model_params, ui_classifiers, debug_buckets, create_model, \
     generate_samples, load_params, start_training, update_extension, start_crop
 from extensions.sd_dreambooth_extension.dreambooth.utils.image_utils import get_scheduler_names
-from extensions.sd_dreambooth_extension.dreambooth.utils.model_utils import get_db_models, get_lora_models
+from extensions.sd_dreambooth_extension.dreambooth.utils.model_utils import get_db_models_for_dropdown, \
+    get_lora_models_for_dropdown, get_model_snapshots_for_dropdown
 from extensions.sd_dreambooth_extension.dreambooth.utils.utils import list_attention, \
     list_floats, wrap_gpu_call, parse_logs, printm, list_optimizer
 from extensions.sd_dreambooth_extension.dreambooth.webhook import save_and_test_webhook
@@ -186,18 +187,29 @@ def on_ui_tabs():
                 gr.HTML(value="<span class='hh'>Model</span>")
                 with gr.Tab("Select"):
                     with gr.Row():
-                        db_model_name = gr.Dropdown(label='Model', choices=sorted(get_db_models()))
-                        create_refresh_button(db_model_name, get_db_models, lambda: {
-                            "choices": sorted(get_db_models())},
-                                              "refresh_db_models")
+                        db_model_name = gr.Dropdown(label='Model', choices=sorted(get_db_models_for_dropdown()))
+                        create_refresh_button(
+                            db_model_name,
+                            get_db_models_for_dropdown,
+                            lambda: {"choices": sorted(get_db_models_for_dropdown())},
+                            "refresh_db_models"
+                        )
                     with gr.Row():
-                        db_snapshot = gr.Dropdown(label="Snapshot to Resume")
+                        db_snapshot = gr.Dropdown(label="Snapshot to Resume", choices=sorted(get_model_snapshots_for_dropdown()))
+                        create_refresh_button(
+                            db_snapshot,
+                            get_model_snapshots_for_dropdown,
+                            lambda: {"choices": sorted(get_model_snapshots_for_dropdown())},
+                            "refresh_db_snapshots"
+                        )
                     with gr.Row(visible=False) as lora_model_row:
-                        db_lora_model_name = gr.Dropdown(label='Lora Model', choices=sorted(get_lora_models()))
-                        create_refresh_button(db_lora_model_name, get_lora_models, lambda: {
-                            "choices": sorted(get_lora_models())},
-                                              "refresh_lora_models")
-
+                        db_lora_model_name = gr.Dropdown(label='Lora Model', choices=sorted(get_lora_models_for_dropdown()))
+                        create_refresh_button(
+                            db_lora_model_name,
+                            get_lora_models_for_dropdown,
+                            lambda: {"choices": sorted(get_lora_models_for_dropdown())},
+                            "refresh_lora_models"
+                        )
                     with gr.Row():
                         gr.HTML(value="Loaded Model:")
                         db_model_path = gr.HTML()

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -439,8 +439,8 @@ def on_ui_tabs():
                                                     label="Batch Size to Simulate")
                         db_generate_sample = gr.Button(value="Generate Sample Images")
                         db_sample_prompt = gr.Textbox(label="Sample Prompt")
-                        db_sample_prompt_file = gr.Textbox(label="Sample Prompt File")
                         db_sample_negative = gr.Textbox(label="Sample Negative Prompt")
+                        db_sample_prompt_file = gr.Textbox(label="Sample Prompt File")
                         db_sample_width = gr.Slider(label="Sample Width", value=512, step=64, minimum=128, maximum=2048)
                         db_sample_height = gr.Slider(label="Sample Height", value=512, step=64, minimum=128,
                                                      maximum=2048)

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -419,6 +419,7 @@ def on_ui_tabs():
                         db_save_lora_after = gr.Checkbox(label="Generate lora weights when training completes.",
                                                          value=True)
                         db_save_lora_cancel = gr.Checkbox(label="Generate lora weights when training is canceled.")
+                        db_save_lora_for_extra_net = gr.Checkbox(label="Generate lora weights for extra networks.")
                     with gr.Column():
                         gr.HTML("Diffusion Weights")
                         db_save_state_during = gr.Checkbox(
@@ -699,6 +700,7 @@ def on_ui_tabs():
             db_save_lora_after,
             db_save_lora_cancel,
             db_save_lora_during,
+            db_save_lora_for_extra_net,
             db_save_preview_every,
             db_save_safetensors,
             db_save_state_after,

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -941,6 +941,7 @@ def on_ui_tabs():
                 db_has_ema,
                 db_src,
                 db_snapshot,
+                db_lora_model_name,
                 db_status
             ]
         )

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -12,8 +12,8 @@ from extensions.sd_dreambooth_extension.dreambooth.ui_functions import performan
     training_wizard, training_wizard_person, load_model_params, ui_classifiers, debug_buckets, create_model, \
     generate_samples, load_params, start_training, update_extension, start_crop
 from extensions.sd_dreambooth_extension.dreambooth.utils.image_utils import get_scheduler_names
-from extensions.sd_dreambooth_extension.dreambooth.utils.model_utils import get_db_models_for_dropdown, \
-    get_lora_models_for_dropdown, get_model_snapshots_for_dropdown
+from extensions.sd_dreambooth_extension.dreambooth.utils.model_utils import get_db_models, \
+    get_sorted_lora_models, get_model_snapshots
 from extensions.sd_dreambooth_extension.dreambooth.utils.utils import list_attention, \
     list_floats, wrap_gpu_call, parse_logs, printm, list_optimizer
 from extensions.sd_dreambooth_extension.dreambooth.webhook import save_and_test_webhook
@@ -187,27 +187,27 @@ def on_ui_tabs():
                 gr.HTML(value="<span class='hh'>Model</span>")
                 with gr.Tab("Select"):
                     with gr.Row():
-                        db_model_name = gr.Dropdown(label='Model', choices=sorted(get_db_models_for_dropdown()))
+                        db_model_name = gr.Dropdown(label='Model', choices=sorted(get_db_models()))
                         create_refresh_button(
                             db_model_name,
-                            get_db_models_for_dropdown,
-                            lambda: {"choices": sorted(get_db_models_for_dropdown())},
+                            get_db_models,
+                            lambda: {"choices": sorted(get_db_models())},
                             "refresh_db_models"
                         )
                     with gr.Row():
-                        db_snapshot = gr.Dropdown(label="Snapshot to Resume", choices=sorted(get_model_snapshots_for_dropdown()))
+                        db_snapshot = gr.Dropdown(label="Snapshot to Resume", choices=get_sorted_model_snapshots())
                         create_refresh_button(
                             db_snapshot,
-                            get_model_snapshots_for_dropdown,
-                            lambda: {"choices": sorted(get_model_snapshots_for_dropdown())},
+                            get_sorted_model_snapshots,
+                            lambda: {"choices": get_sorted_model_snapshots()},
                             "refresh_db_snapshots"
                         )
                     with gr.Row(visible=False) as lora_model_row:
-                        db_lora_model_name = gr.Dropdown(label='Lora Model', choices=sorted(get_lora_models_for_dropdown()))
+                        db_lora_model_name = gr.Dropdown(label='Lora Model', choices=get_sorted_lora_models())
                         create_refresh_button(
                             db_lora_model_name,
-                            get_lora_models_for_dropdown,
-                            lambda: {"choices": sorted(get_lora_models_for_dropdown())},
+                            get_sorted_lora_models,
+                            lambda: {"choices": get_sorted_lora_models()},
                             "refresh_lora_models"
                         )
                     with gr.Row():

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -195,11 +195,11 @@ def on_ui_tabs():
                             "refresh_db_models"
                         )
                     with gr.Row():
-                        db_snapshot = gr.Dropdown(label="Snapshot to Resume", choices=get_sorted_model_snapshots())
+                        db_snapshot = gr.Dropdown(label="Snapshot to Resume", choices=sorted(get_model_snapshots()))
                         create_refresh_button(
                             db_snapshot,
-                            get_sorted_model_snapshots,
-                            lambda: {"choices": get_sorted_model_snapshots()},
+                            get_model_snapshots,
+                            lambda: {"choices": sorted(get_model_snapshots())},
                             "refresh_db_snapshots"
                         )
                     with gr.Row(visible=False) as lora_model_row:


### PR DESCRIPTION
## Describe your changes

When option is selected, when saving loras (modelname_steps.pt) we will also save modelname_steps.safetensors that is compatible with a1111 extra networks.

This change implements a new safetensor format for loras.
 - It does not support extended lora
 - We move .pt file generation to a new folder db_loras configured as db_lora_models_path. Introduce ui_lora_models_path for extra networks models.

## Issue ticket number and link (if applicable)

## Checklist before requesting a review
- [x] This is based on the /dev branch (Or a fork of it)
- [x] This was created or at least validated using a proper IDE
- [x] I have tested this code and validated any modified functions
- [x] I have added the appropriate documentation and hint strings if adding or changing a user-facing feature
