### PR TITLE
Ensure args.revision int

### DIFF
--- a/dreambooth/train_dreambooth.py
+++ b/dreambooth/train_dreambooth.py
@@ -874,6 +874,7 @@ def main(use_txt2img: bool = True) -> TrainResult:
         progress_bar = mytqdm(range(global_step, max_train_steps), disable=not accelerator.is_local_main_process)
         progress_bar.set_description("Steps")
         progress_bar.set_postfix(refresh=True)
+        args.revision = args.revision if isinstance(args.revision,int) else int(args.revision) if str.strip(args.revision) != "" else 0
         lifetime_step = args.revision
         lifetime_epoch = args.epoch
         status.job_count = max_train_steps


### PR DESCRIPTION
## Describe your changes
Sometime, loading a saved settings for training, revision comes as string, which leads to errors when math is done on it (calculating steps). This help ensure revision is int before its being used.


## Checklist before requesting a review
- [x ] This is based on the /dev branch (Or a fork of it)
- [x] This was created or at least validated using a proper IDE
- [x] I have tested this code and validated any modified functions
- [x] I have added the appropriate documentation and hint strings if adding or changing a user-facing feature
