### PR TITLE
Fix image builder breaking when use_lora is false and lora_model is null

### DIFF
--- a/helpers/image_builder.py
+++ b/helpers/image_builder.py
@@ -123,21 +123,22 @@ class ImageBuilder:
                 accelerator.load_state(new_hotness)
                 enable_safe_unpickle()
 
-            lora_model_path = os.path.join(shared.models_path, "lora", lora_model)
-            if config.use_lora and os.path.exists(lora_model_path) and lora_model != "":
-                patch_pipe(
-                    pipe=self.image_pipe,
-                    maybe_unet_path=lora_model_path,
-                    unet_target_replace_module=get_target_module("module", config.use_lora_extended),
-                    token=None,
-                    r=lora_unet_rank,
-                    r_txt=lora_txt_rank
-                )
-                tune_lora_scale(self.image_pipe.unet, config.lora_weight)
+            if config.use_lora and lora_model != "":
+                lora_model_path = os.path.join(shared.models_path, "lora", lora_model)
+                if os.path.exists(lora_model_path):
+                    patch_pipe(
+                        pipe=self.image_pipe,
+                        maybe_unet_path=lora_model_path,
+                        unet_target_replace_module=get_target_module("module", config.use_lora_extended),
+                        token=None,
+                        r=lora_unet_rank,
+                        r_txt=lora_txt_rank
+                    )
+                    tune_lora_scale(self.image_pipe.unet, config.lora_weight)
 
-                lora_txt_path = _text_lora_path_ui(lora_model_path)
-                if os.path.exists(lora_txt_path):
-                    tune_lora_scale(self.image_pipe.text_encoder, config.lora_txt_weight)
+                    lora_txt_path = _text_lora_path_ui(lora_model_path)
+                    if os.path.exists(lora_txt_path):
+                        tune_lora_scale(self.image_pipe.text_encoder, config.lora_txt_weight)
 
         else:
             try:


### PR DESCRIPTION
## Describe your changes

Fixes TypeError: join() argument must be str, bytes, or os.PathLike object, not 'list' error when generating images without lora. The previous code attempted to construct the path while lora_model = null. 

## Issue ticket number and link (if applicable)

## Checklist before requesting a review
- [ ] This is based on the /dev branch (Or a fork of it)
- [x] This was created or at least validated using a proper IDE
- [x] I have tested this code and validated any modified functions
- [ ] I have added the appropriate documentation and hint strings if adding or changing a user-facing feature
