### PR TITLE
grep not exist on Windows without GnuWin

### DIFF
--- a/postinstall.py
+++ b/postinstall.py
@@ -319,6 +319,6 @@ def install_requirements(req_file, package_name):
         output = subprocess.check_output([sys.executable, "-m", "pip", "install", "-r", req_file], universal_newlines=True)
         pattern = re.compile(r'^((?!already satisfied).)*$', re.MULTILINE)
         filtered_output = pattern.findall(output)
-        print(f"{package_name} requirements successfully installed.")
+        print(f"Checking {package_name} requirements...")
     except subprocess.CalledProcessError:
         print(f"Failed to install {package_name} requirements.")

--- a/postinstall.py
+++ b/postinstall.py
@@ -282,8 +282,7 @@ def actual_install():
 
     if not dreambooth_skip_install:
         name = "Dreambooth"
-        run(f'"{sys.executable}" -m pip install -r "{req_file}" | grep -v "already satisfied"', f"Checking {name} requirements...",
-            f"Couldn't install {name} requirements.")
+        install_requirements(req_file, name)
 
     python = sys.executable
 
@@ -314,3 +313,12 @@ def actual_install():
         torch.load = safe.unsafe_torch_load
     except:
         pass
+
+def install_requirements(req_file, package_name):
+    try:
+        output = subprocess.check_output([sys.executable, "-m", "pip", "install", "-r", req_file], universal_newlines=True)
+        pattern = re.compile(r'^((?!already satisfied).)*$', re.MULTILINE)
+        filtered_output = pattern.findall(output)
+        print(f"{package_name} requirements successfully installed.")
+    except subprocess.CalledProcessError:
+        print(f"Failed to install {package_name} requirements.")


### PR DESCRIPTION
## Describe your changes
`grep` is Unix command that not exist on Windows without installing GnuWin.
Perhaps using `findstr`, but python it self has better option.

This code runs any Operating System (Windows, Linux, macOS, ...)

## Issue ticket number and link (if applicable)
-

## Checklist before requesting a review
- [ ] This is based on the /dev branch (Or a fork of it)
- [x] This was created or at least validated using a proper IDE
- [x] I have tested this code and validated any modified functions
- [ ] I have added the appropriate documentation and hint strings if adding or changing a user-facing feature
