### PR TITLE
Fix filewords in class prompt

### DIFF
--- a/dreambooth/dataset/class_dataset.py
+++ b/dreambooth/dataset/class_dataset.py
@@ -70,6 +70,9 @@ class ClassDataset(Dataset):
                 class_prompt_datas = sort_prompts(concept, text_getter, class_dir, c_images[c_idx], bucket_resos, c_idx,
                                                   True, pbar)
 
+            # Create list of filewords from instance images
+            instance_img_filewords = [text_getter.read_text(img) for img in i_images[c_idx]]
+
             # Iterate over each resolution of images, per concept
             for res, i_prompt_datas in instance_prompt_datas.items():
                 # Extend instance prompts by the instance data
@@ -97,7 +100,7 @@ class ClassDataset(Dataset):
                     instance_prompts = [img.prompt for img in i_prompt_datas]
 
                     if "[filewords]" in concept.class_prompt:
-                        for prompt in instance_prompts:
+                        for prompt in instance_img_filewords:
                             sample_prompt = text_getter.create_text(
                                 concept.class_prompt, prompt, concept.instance_token, concept.class_token, True)
                             num_to_gen = concept.num_class_images_per - class_prompts.count(sample_prompt)


### PR DESCRIPTION
## Describe your changes
Fixes a bug when creating classification images with [filewords] in the class prompt.

Currently if the class prompt contains "[filewords]", then the instance prompt is added to the class prompt in place of "[filewords]" when creating class images:
![Screenshot from 2023-03-08 21-53-37](https://user-images.githubusercontent.com/43688805/223933673-8d588f1c-d318-4645-94ef-de7ab6ce0cfd.png)
![Screenshot from 2023-03-08 21-56-22](https://user-images.githubusercontent.com/43688805/223933776-9564ea7c-e183-4e5d-b547-cd99aaee66fe.png)


These changes will add the [filewords] from instance images in place of "[filewords]" in class prompts when creating class images:
![Screenshot from 2023-03-08 22-11-08](https://user-images.githubusercontent.com/43688805/223936614-1bbd3b9c-67ab-4b73-b0cf-016acffee679.png)
![Screenshot from 2023-03-08 22-16-33](https://user-images.githubusercontent.com/43688805/223936626-3a6cd58a-9685-4c6e-9520-67794ac7cc76.png)

## Issue ticket number and link (if applicable)


## Checklist before requesting a review
- [ ] This is based on the /dev branch (Or a fork of it)
- [ ] This was created or at least validated using a proper IDE
- [ ] I have tested this code and validated any modified functions
- [ ] I have added the appropriate documentation and hint strings if adding or changing a user-facing feature
