### PR TITLE
Fix bucket_sampler shuffling

### DIFF
--- a/dreambooth/dataset/bucket_sampler.py
+++ b/dreambooth/dataset/bucket_sampler.py
@@ -69,7 +69,8 @@ class BucketSampler:
 
     def fill_batch(self):
         current_res = self.active_resos[self.current_bucket]
-        self.dataset.shuffle_buckets()
+        if self.current_bucket == 0 and self.dataset.image_index == 0:
+            self.dataset.shuffle_buckets()
         batch = []
         repeats = 0
         while len(batch) < self.batch_size:


### PR DESCRIPTION
Currently the bucket_sampler shuffles all the elements on every call to If you batch size is less than your epoch size, this means it is not processing every image in the epoch.

## Describe your changes
Fixes bucket_sampler to properly use each input in an epoch.

Testing on a one bucket training. Would be nice if someone how uses multiple resolutions could test, but I might just push it.

## Issue ticket number and link (if applicable)

## Checklist before requesting a review
- [x] This is based on the /dev branch (Or a fork of it)
- [x] This was created or at least validated using a proper IDE
- [x] I have tested this code and validated any modified functions
- [ ] I have added the appropriate documentation and hint strings if adding or changing a user-facing feature
