### PR TITLE
fix: error to save model without lora.

### DIFF
--- a/dreambooth/diff_to_sd.py
+++ b/dreambooth/diff_to_sd.py
@@ -430,7 +430,8 @@ def compile_checkpoint(model_name: str, lora_file_name: str = None, reload_model
                 pass
 
         # Apply LoRA to the unet
-        if lora_file_name is not None and lora_file_name != "":
+        print("### lora_file_name: ", lora_file_name)
+        if lora_file_name is not None and lora_file_name != "" and lora_file_name != []:
             unet_model = UNet2DConditionModel().from_pretrained(os.path.dirname(unet_path))
             lora_rev = apply_lora(config, unet_model, lora_file_name, "cpu", False)
             unet_state_dict = copy.deepcopy(unet_model.state_dict())
@@ -459,7 +460,7 @@ def compile_checkpoint(model_name: str, lora_file_name: str = None, reload_model
         printi("Converting text encoder...", log=log)
 
         # Apply lora weights to the tenc
-        if lora_file_name is not None and lora_file_name != "":
+        if lora_file_name is not None and lora_file_name != "" and lora_file_name != []:
             lora_paths = lora_file_name.split(".")
             lora_txt_file_name = f"{lora_paths[0]}_txt.{lora_paths[1]}"
             text_encoder_cls = import_model_class_from_model_name_or_path(config.pretrained_model_name_or_path,


### PR DESCRIPTION
just for fix: with 'Use LORA' option as false, cannot save model by hand.

## Describe your changes
just judge if the 'lora_file_name' == []

## Fix
when I fail to save model during the train finished (no space on device),I tried to add disk space and reboot webui. But I find i cann't just chose the last model name and click the 'Generate ckpt' button to save my model.  
```
Model dir set to: models/dreambooth/artpeople-03-17
Lora path: []
Model dir set to: models/dreambooth/artpeople-03-17
Compiling checkpoint for artpeople-03-17 with a custom name artPeople-03-17
Exception compiling checkpoint: stat: path should be string, bytes, os.PathLike or integer, not list
Traceback (most recent call last):
  File "/root/autodl-tmp/stable-diffusion-webui/extensions/sd_dreambooth_extension/dreambooth/diff_to_sd.py", line 435, in compile_checkpoint
    unet_model = UNet2DConditionModel().from_pretrained(os.path.dirname(unet_path))
  File "/root/autodl-tmp/stable-diffusion-webui/extensions/sd_dreambooth_extension/dreambooth/diff_to_sd.py", line 567, in apply_lora
    if lora_file_name is not None and lora_file_name != "":
  File "/root/miniconda3/lib/python3.8/genericpath.py", line 19, in exists
    os.stat(path)
TypeError: stat: path should be string, bytes, os.PathLike or integer, not list
Duration: 00:00:10
```
So I print the lora_file_name, and find it is [] by default.
