### PR TITLE
Fix/workaround for model_name being a list

### DIFF
--- a/dreambooth/dataclasses/db_config.py
+++ b/dreambooth/dataclasses/db_config.py
@@ -374,6 +374,9 @@ def from_file(model_name):
     Returns: Dict | None
 
     """
+    if isinstance(model_name, list) and len(model_name) > 0:
+        model_name = model_name[0]
+        
     if model_name == "" or model_name is None:
         return None
 


### PR DESCRIPTION
The model_name is getting passed in as a single element list for me.  The existing code doesn't handle that case, sanitize_name ends up returning an empty string, then open() throws because the db_config.json doesn't exist in the wrong path.

I don't know the root cause of this issue, maybe some of the automatic1111 UI library updates changed some behavior here.

## Describe your changes

- Adds a line to handle the case I'm seeing, where model_name is a list.
- Based on main (currently ahead of dev)
