### PR TITLE
Allow LoRA model training to use shared diffusers models

### DIFF
--- a/dreambooth/dataclasses/db_config.py
+++ b/dreambooth/dataclasses/db_config.py
@@ -102,6 +102,7 @@ class DreamboothConfig(BaseModel):
     save_state_cancel: bool = False
     save_state_during: bool = False
     scheduler: str = "ddim"
+    shared_diffusers_path: str = ""
     shuffle_tags: bool = True
     snapshot: str = ""
     split_loss: bool = True
@@ -307,6 +308,11 @@ class DreamboothConfig(BaseModel):
             print(f"Exception loading config: {e}")
             traceback.print_exc()
             return None
+    
+    def get_pretrained_model_name_or_path(self):
+        if (self.shared_diffusers_path != "" and not self.use_lora):
+            raise Exception(f"shared_diffusers_path is \"{self.shared_diffusers_path}\" but use_lora is false")
+        return self.shared_diffusers_path if self.shared_diffusers_path != "" else self.pretrained_model_name_or_path
 
 
 def concepts_from_file(concepts_path: str):

--- a/dreambooth/diff_to_sd.py
+++ b/dreambooth/diff_to_sd.py
@@ -400,7 +400,7 @@ def compile_checkpoint(model_name: str, lora_file_name: str = None, reload_model
     checkpoint_ext = ".ckpt" if not config.save_safetensors else ".safetensors"
     checkpoint_path = os.path.join(models_path, f"{save_model_name}_{total_steps}{checkpoint_ext}")
 
-    model_path = config.pretrained_model_name_or_path
+    model_path = config.get_pretrained_model_name_or_path()
 
     new_hotness = os.path.join(config.model_dir, "checkpoints", f"checkpoint-{snap_rev}")
     if snap_rev and os.path.exists(new_hotness) and os.path.isdir(new_hotness):
@@ -467,11 +467,11 @@ def compile_checkpoint(model_name: str, lora_file_name: str = None, reload_model
         if lora_file_name:
             lora_paths = lora_file_name.split(".")
             lora_txt_file_name = f"{lora_paths[0]}_txt.{lora_paths[1]}"
-            text_encoder_cls = import_model_class_from_model_name_or_path(config.pretrained_model_name_or_path,
+            text_encoder_cls = import_model_class_from_model_name_or_path(config.get_pretrained_model_name_or_path(),
                                                                           config.revision)
 
             text_encoder = text_encoder_cls.from_pretrained(
-                config.pretrained_model_name_or_path,
+                config.get_pretrained_model_name_or_path(),
                 subfolder="text_encoder",
                 revision=config.revision,
                 torch_dtype=torch.float32

--- a/dreambooth/optimization.py
+++ b/dreambooth/optimization.py
@@ -589,5 +589,5 @@ def get_noise_scheduler(args):
         scheduler_class = DDPMScheduler
 
     return scheduler_class.from_pretrained(
-        args.pretrained_model_name_or_path, subfolder="scheduler"
+        args.get_pretrained_model_name_or_path(), subfolder="scheduler"
     )

--- a/dreambooth/sd_to_diff.py
+++ b/dreambooth/sd_to_diff.py
@@ -38,7 +38,7 @@ from dreambooth import shared
 from dreambooth.dataclasses.db_config import DreamboothConfig
 from dreambooth.utils.image_utils import get_scheduler_class
 from dreambooth.utils.model_utils import get_db_models, disable_safe_unpickle, \
-    enable_safe_unpickle
+    enable_safe_unpickle, LORA_SHARED_SRC_CREATE
 from dreambooth.utils.utils import printi
 from helpers.mytqdm import mytqdm
 
@@ -1008,12 +1008,43 @@ def load_checkpoint(checkpoint_file: str, map_location: str):
     return checkpoint
 
 
-def extract_checkpoint(new_model_name: str, checkpoint_file: str, from_hub=False, new_model_url="",
+def copy_config_file(original_config_file, dest_dir, model_name):
+    if original_config_file is not None and os.path.exists(original_config_file):
+        shutil.copy(original_config_file, dest_dir)
+        basename = os.path.basename(original_config_file)
+        if basename == f"{model_name}.yaml":
+            return
+        new_ex_path = os.path.join(dest_dir, basename)
+        new_name = os.path.join(dest_dir, f"{model_name}.yaml")
+        if os.path.exists(new_name):
+            os.remove(new_name)
+        os.rename(new_ex_path, new_name)
+
+def is_v2_from_diffuers_unet(unet_dir):
+    v2 = False
+    print(f'Loading UNet from {unet_dir}')
+    try:
+        unet = UNet2DConditionModel.from_pretrained(unet_dir)
+        print("Loaded unet.")
+        unet_dict = unet.state_dict()
+        key_name = "down_blocks.2.attentions.1.transformer_blocks.0.attn2.to_k.weight"
+        if key_name in unet_dict and unet_dict[key_name].shape[-1] == 1024:
+            print("We got v2!")
+            v2 = True
+        del unet
+    except:
+        print("Exception loading unet!")
+        traceback.print_exc()
+    return v2
+
+
+def extract_checkpoint(new_model_name: str, checkpoint_file: str, shared_src_name: str, from_hub=False, new_model_url="",
                        new_model_token="", extract_ema=False, train_unfrozen=False, is_512=True):
     """
 
     @param new_model_name: The name of the new model
     @param checkpoint_file: The source checkpoint to use, if not from hub. Needs full path
+    @param shared_src_name: Name of shared diffusers source for LoRA
     @param from_hub: Are we making this model from the hub?
     @param new_model_url: The URL to pull. Should be formatted like compviz/stable-diffusion-2, not a full URL.
     @param new_model_token: Your huggingface.co token.
@@ -1027,6 +1058,7 @@ def extract_checkpoint(new_model_name: str, checkpoint_file: str, from_hub=False
         db_config.epoch: Model epoch
         db_config.scheduler: The scheduler being used
         db_config.src: The source checkpoint, if not from hub.
+        db_config.db_shared_diffusers_path: Path to the shared LoRA source.
         db_has_ema: Whether the model had EMA weights and they were extracted. If weights were not present or
         you did not extract them and they were, this will be false.
         db_resolution: The resolution the model trains at.
@@ -1049,12 +1081,14 @@ def extract_checkpoint(new_model_name: str, checkpoint_file: str, from_hub=False
             new_model_token is None or new_model_token == ""):
         msg = "Please provide a URL and token for huggingface models."
     if msg is not None:
-        return "", "", 0, 0, "", "", "", "", image_size, "", msg
+        return "", "", 0, 0, "", "", "", "", "", image_size, "", msg
 
+    result_status = ""
     # Create empty config
     db_config = DreamboothConfig(model_name=new_model_name, src=checkpoint_file if not from_hub else new_model_url)
 
     original_config_file = None
+    shared_src = ""
 
     # Okay then. So, if it's from the hub, try to download it
     if from_hub:
@@ -1073,252 +1107,271 @@ def extract_checkpoint(new_model_name: str, checkpoint_file: str, from_hub=False
             print(msg)
             return "", "", 0, 0, "", "", "", "", image_size, "", msg
 
-    shared.status.job_count = 11
-
-    try:
-        shared.status.job_no = 0
-        checkpoint = None
-        map_location = shared.device
-        try:
-            if shared.ckptfix or shared.medvram or shared.lowvram:
-                print(f"Using CPU for extraction.")
-                map_location = torch.device('cpu')
-        except:
-            print("UPDATE YOUR WEBUI!!!!")
-            return "", "", 0, 0, "", "", "", "", image_size, "", "Update your web UI."
-
-        # Try to determine if v1 or v2 model if we have a ckpt
-        if not from_hub:
-            printi("Loading model from checkpoint.")
-            checkpoint = load_checkpoint(checkpoint_file, map_location)
-
-            rev_keys = ["db_global_step", "global_step"]
-            epoch_keys = ["db_epoch", "epoch"]
-            for key in rev_keys:
-                if key in checkpoint:
-                    revision = checkpoint[key]
-                    break
-
-            for key in epoch_keys:
-                if key in checkpoint:
-                    epoch = checkpoint[key]
-                    break
-
-            key_name = "model.diffusion_model.input_blocks.2.1.transformer_blocks.0.attn2.to_k.weight"
-            if key_name in checkpoint and checkpoint[key_name].shape[-1] == 1024:
-                if not is_512:
-                    # v2.1 needs to upcast attention
-                    print("Setting upcast_attention")
-                    upcast_attention = True
-                v2 = True
-            else:
-                v2 = False
-        else:
-            unet_dir = os.path.join(db_config.pretrained_model_name_or_path, "unet")
-            print(f'Loading UNet from {unet_dir}')
-            try:
-                unet = UNet2DConditionModel.from_pretrained(unet_dir)
-                print("Loaded unet.")
-                unet_dict = unet.state_dict()
-                key_name = "down_blocks.2.attentions.1.transformer_blocks.0.attn2.to_k.weight"
-                if key_name in unet_dict and unet_dict[key_name].shape[-1] == 1024:
-                    print("We got v2!")
-                    v2 = True
-
-            except:
-                print("Exception loading unet!")
-                traceback.print_exc()
-
-        if v2 and not is_512:
-            prediction_type = "v_prediction"
-        else:
-            prediction_type = "epsilon"
-
-        original_config_file = get_config_file(train_unfrozen, v2, prediction_type)
-
-        print(f"Pred and size are {prediction_type} and {image_size}, using config: {original_config_file}")
-        db_config.resolution = image_size
-        db_config.lifetime_revision = revision
-        db_config.epoch = epoch
-        db_config.v2 = v2
-        if from_hub:
-            result_status = "Model fetched from hub."
-            db_config.save()
-
-            return gr_update(choices=sorted(get_db_models()), value=new_model_name), \
-                db_config.model_dir, \
-                revision, \
-                epoch, \
-                db_config.scheduler, \
-                db_config.src, \
-                "True" if has_ema else "False", \
-                "True" if v2 else "False", \
-                db_config.resolution, \
-                result_status
-
-        print(f"{'v2' if v2 else 'v1'} model loaded.")
-
-        # Use existing YAML if present
-        if checkpoint_file is not None:
-            config_check = checkpoint_file.replace(".ckpt",
-                                                   ".yaml") if ".ckpt" in checkpoint_file else checkpoint_file.replace(
-                ".safetensors", ".yaml")
-            if os.path.exists(config_check):
-                original_config_file = config_check
-
-        if original_config_file is None or not os.path.exists(original_config_file):
-            print("Unable to select a config file.")
-            return "", "", 0, 0, "", "", "", "", image_size, "", "Unable to find a config file."
-
-        print(f"Trying to load: {original_config_file}")
-        original_config = OmegaConf.load(original_config_file)
-
-        num_train_timesteps = original_config.model.params.timesteps
-        beta_start = original_config.model.params.linear_start
-        beta_end = original_config.model.params.linear_end
-
-        scheduler = DDIMScheduler(
-            beta_end=beta_end,
-            beta_schedule="scaled_linear",
-            beta_start=beta_start,
-            num_train_timesteps=num_train_timesteps,
-            steps_offset=1,
-            clip_sample=False,
-            set_alpha_to_one=False,
-            prediction_type=prediction_type,
-        )
-        # make sure scheduler works correctly with DDIM
-        scheduler.register_to_config(clip_sample=False)
-        scheduler = get_scheduler_class("DEISMultistep").from_config(scheduler.config)
-
-        scheduler_type = scheduler.__class__.__name__
-        scheduler.save_pretrained(os.path.join(db_config.pretrained_model_name_or_path, "scheduler"))
-
-        printi("Converting unet...")
-        # Convert the UNet2DConditionModel model.
-        unet_config = create_unet_diffusers_config(original_config, image_size=image_size)
-        unet_config["upcast_attention"] = upcast_attention
-        unet = UNet2DConditionModel(**unet_config)
-
-        converted_unet_checkpoint, converted_ema_checkpoint = convert_ldm_unet_checkpoint(
-            checkpoint, unet_config, path=checkpoint_file, extract_ema=extract_ema
-        )
-        unet.load_state_dict(converted_unet_checkpoint)
-        unet.save_pretrained(os.path.join(db_config.pretrained_model_name_or_path, "unet"), safe_serialization=True)
-        del unet
-
-        if converted_ema_checkpoint is not None:
-            print("Saving EMA unet.")
-            has_ema = True
-            ema_unet = UNet2DConditionModel(**unet_config)
-            ema_unet.load_state_dict(converted_ema_checkpoint)
-            ema_unet.save_pretrained(os.path.join(db_config.pretrained_model_name_or_path, "ema_unet"),
-                                     safe_serialization=True)
-
-            del ema_unet
-            db_config.has_ema = has_ema
-
+    if shared_src_name and shared_src_name != LORA_SHARED_SRC_CREATE:
+        db_config.shared_diffusers_path = os.path.join(shared.models_path, "diffusers", shared_src_name, "working")
+        db_config.use_lora = True
+        db_config.pretrained_model_name_or_path = ""
+        original_config_file = os.path.join(shared.models_path, "diffusers", shared_src_name, ".yaml")
+        db_config.src = db_config.shared_diffusers_path
+        
+        unet_dir = os.path.join(db_config.shared_diffusers_path, "unet")
+        db_config.v2 = is_v2_from_diffuers_unet(unet_dir)
         db_config.save()
-        printi("Converting vae...")
-        # Convert the VAE model.
-        vae_config = create_vae_diffusers_config(original_config, image_size=image_size)
-        converted_vae_checkpoint = convert_ldm_vae_checkpoint(checkpoint, vae_config)
+        result_status = f"Shared source {shared_src_name} configured."
 
-        vae = AutoencoderKL(**vae_config)
-        vae.load_state_dict(converted_vae_checkpoint)
-        vae.save_pretrained(os.path.join(db_config.pretrained_model_name_or_path, "vae"), safe_serialization=True)
-        del vae
+    else:
+        shared.status.job_count = 11
 
-        printi("Converting text encoder...")
-        # Convert the text model.
-        text_model_type = original_config.model.params.cond_stage_config.target.split(".")[-1]
-        tokenizer_type = "CLIPTokenizer"
-        if text_model_type == "FrozenOpenCLIPEmbedder":
-            text_model = convert_open_clip_checkpoint(checkpoint)
-            tokenizer = CLIPTokenizer.from_pretrained("stabilityai/stable-diffusion-2", subfolder="tokenizer")
-        elif text_model_type == "FrozenCLIPEmbedder":
-            text_model = convert_ldm_clip_checkpoint(checkpoint)
-            tokenizer = CLIPTokenizer.from_pretrained("openai/clip-vit-large-patch14")
-        else:
-            text_config = create_ldm_bert_config(original_config)
-            text_model = convert_ldm_bert_checkpoint(checkpoint, text_config)
-            tokenizer = BertTokenizerFast.from_pretrained("bert-base-uncased")
-            tokenizer_type = "BertTokenizerFast"
+        try:
+            
+            if shared_src_name:
+                ckpt_basename = os.path.basename(checkpoint_file)
+                shared_src, _ = os.path.splitext(ckpt_basename)
+                db_config.pretrained_model_name_or_path = os.path.join(shared.models_path, "diffusers", shared_src, "working")
+                db_config.shared_diffusers_path = db_config.pretrained_model_name_or_path
+                db_config.use_lora = True
+                if os.path.exists(db_config.pretrained_model_name_or_path):
+                    msg = f"<create new> failed. {db_config.pretrained_model_name_or_path} already exists."
+                    printi(msg)
+                    return "", "", 0, 0, "", "", "", "", image_size, "", msg
+            
+            shared.status.job_no = 0
+            checkpoint = None
+            map_location = shared.device
+            try:
+                if shared.ckptfix or shared.medvram or shared.lowvram:
+                    print(f"Using CPU for extraction.")
+                    map_location = torch.device('cpu')
+            except:
+                print("UPDATE YOUR WEBUI!!!!")
+                return "", "", 0, 0, "", "", "", "", "", image_size, "", "Update your web UI."
 
-        to_save = {"text_encoder": text_model, "tokenizer": tokenizer}
+            # Try to determine if v1 or v2 model if we have a ckpt
+            if not from_hub:
+                printi("Loading model from checkpoint.")
+                checkpoint = load_checkpoint(checkpoint_file, map_location)
 
-        for name, model in to_save.items():
-            if model is None:
-                continue
-            print(f"Saving {name}")
-            model.save_pretrained(os.path.join(db_config.pretrained_model_name_or_path, name), safe_serialization=True)
-            del model
+                rev_keys = ["db_global_step", "global_step"]
+                epoch_keys = ["db_epoch", "epoch"]
+                for key in rev_keys:
+                    if key in checkpoint:
+                        revision = checkpoint[key]
+                        break
 
-        del checkpoint
+                for key in epoch_keys:
+                    if key in checkpoint:
+                        epoch = checkpoint[key]
+                        break
 
-        if "nonema" in checkpoint_file and extract_ema:
-            ema_checkpoint_file = checkpoint_file.replace("nonema", "ema")
-            if os.path.exists(ema_checkpoint_file):
-                printi("Extracting secondary checkpoint for EMA weights.")
-                checkpoint = load_checkpoint(ema_checkpoint_file, map_location)
-                unet = UNet2DConditionModel(**unet_config)
+                key_name = "model.diffusion_model.input_blocks.2.1.transformer_blocks.0.attn2.to_k.weight"
+                if key_name in checkpoint and checkpoint[key_name].shape[-1] == 1024:
+                    if not is_512:
+                        # v2.1 needs to upcast attention
+                        print("Setting upcast_attention")
+                        upcast_attention = True
+                    v2 = True
+                else:
+                    v2 = False
+            else:
+                unet_dir = os.path.join(db_config.pretrained_model_name_or_path, "unet")
+                v2 = is_v2_from_diffuers_unet(unet_dir)
 
-                converted_unet_checkpoint, _ = convert_ldm_unet_checkpoint(
-                    checkpoint, unet_config, path=checkpoint_file
-                )
+            if v2 and not is_512:
+                prediction_type = "v_prediction"
+            else:
+                prediction_type = "epsilon"
 
-                unet.load_state_dict(converted_unet_checkpoint)
-                unet.save_pretrained(os.path.join(db_config.pretrained_model_name_or_path, "ema_unet"),
-                                     safe_serialization=True)
-                del unet
-                db_config.has_ema = has_ema
+            original_config_file = get_config_file(train_unfrozen, v2, prediction_type)
 
+            print(f"Pred and size are {prediction_type} and {image_size}, using config: {original_config_file}")
+            db_config.resolution = image_size
+            db_config.lifetime_revision = revision
+            db_config.epoch = epoch
+            db_config.v2 = v2
+            if from_hub:
+                result_status = "Model fetched from hub."
                 db_config.save()
 
-        try:
-            diff_ver = importlib_metadata.version("diffusers")
-        except:
-            diff_ver = "0.10.2"
+                return gr_update(choices=sorted(get_db_models()), value=new_model_name), \
+                    db_config.model_dir, \
+                    revision, \
+                    epoch, \
+                    db_config.scheduler, \
+                    db_config.src, \
+                    db_config.shared_diffusers_path, \
+                    "True" if has_ema else "False", \
+                    "True" if v2 else "False", \
+                    db_config.resolution, \
+                    result_status
 
-        ckpt_config = {
-            "_class_name": "StableDiffusionPipeline",
-            "_diffusers_version": diff_ver,
-            "feature_extractor": [None, None],
-            "requires_safety_checker": None,
-            "safety_checker": [None, None],
-            "scheduler": ["diffusers", scheduler_type],
-            "text_encoder": ["transformers", "CLIPTextModel"],
-            "tokenizer": ["transformers", tokenizer_type],
-            "unet": ["diffusers", "UNet2DConditionModel"],
-            "vae": ["diffusers", "AutoencoderKL"]
-        }
-        if db_config.has_ema:
-            ckpt_config["ema_unet"] = ["diffusers", "UNet2DConditionModel"]
+            print(f"{'v2' if v2 else 'v1'} model loaded.")
 
-        idx_file = os.path.join(db_config.pretrained_model_name_or_path, "model_index.json")
-        with open(idx_file, "w") as iof:
-            json.dump(ckpt_config, iof, indent=4)
+            # Use existing YAML if present
+            if checkpoint_file is not None:
+                config_check = checkpoint_file.replace(".ckpt",
+                                                    ".yaml") if ".ckpt" in checkpoint_file else checkpoint_file.replace(
+                    ".safetensors", ".yaml")
+                if os.path.exists(config_check):
+                    original_config_file = config_check
 
-    except Exception as e:
-        print(f"Exception setting up output: {e}")
-        traceback.print_exc()
+            if original_config_file is None or not os.path.exists(original_config_file):
+                print("Unable to select a config file.")
+                return "", "", 0, 0, "", "", "", "", "", image_size, "", "Unable to find a config file."
 
-    result_status = f"Checkpoint successfully extracted to {db_config.pretrained_model_name_or_path}"
+            print(f"Trying to load: {original_config_file}")
+            original_config = OmegaConf.load(original_config_file)
+
+            num_train_timesteps = original_config.model.params.timesteps
+            beta_start = original_config.model.params.linear_start
+            beta_end = original_config.model.params.linear_end
+
+            scheduler = DDIMScheduler(
+                beta_end=beta_end,
+                beta_schedule="scaled_linear",
+                beta_start=beta_start,
+                num_train_timesteps=num_train_timesteps,
+                steps_offset=1,
+                clip_sample=False,
+                set_alpha_to_one=False,
+                prediction_type=prediction_type,
+            )
+            # make sure scheduler works correctly with DDIM
+            scheduler.register_to_config(clip_sample=False)
+            scheduler = get_scheduler_class("DEISMultistep").from_config(scheduler.config)
+
+            scheduler_type = scheduler.__class__.__name__
+            scheduler.save_pretrained(os.path.join(db_config.pretrained_model_name_or_path, "scheduler"))
+
+            printi("Converting unet...")
+            # Convert the UNet2DConditionModel model.
+            unet_config = create_unet_diffusers_config(original_config, image_size=image_size)
+            unet_config["upcast_attention"] = upcast_attention
+            unet = UNet2DConditionModel(**unet_config)
+
+            converted_unet_checkpoint, converted_ema_checkpoint = convert_ldm_unet_checkpoint(
+                checkpoint, unet_config, path=checkpoint_file, extract_ema=extract_ema
+            )
+            unet.load_state_dict(converted_unet_checkpoint)
+            unet.save_pretrained(os.path.join(db_config.pretrained_model_name_or_path, "unet"), safe_serialization=True)
+            del unet
+
+            if converted_ema_checkpoint is not None:
+                print("Saving EMA unet.")
+                has_ema = True
+                ema_unet = UNet2DConditionModel(**unet_config)
+                ema_unet.load_state_dict(converted_ema_checkpoint)
+                ema_unet.save_pretrained(os.path.join(db_config.pretrained_model_name_or_path, "ema_unet"),
+                                        safe_serialization=True)
+
+                del ema_unet
+                db_config.has_ema = has_ema
+
+            db_config.save()
+            printi("Converting vae...")
+            # Convert the VAE model.
+            vae_config = create_vae_diffusers_config(original_config, image_size=image_size)
+            converted_vae_checkpoint = convert_ldm_vae_checkpoint(checkpoint, vae_config)
+
+            vae = AutoencoderKL(**vae_config)
+            vae.load_state_dict(converted_vae_checkpoint)
+            vae.save_pretrained(os.path.join(db_config.pretrained_model_name_or_path, "vae"), safe_serialization=True)
+            del vae
+
+            printi("Converting text encoder...")
+            # Convert the text model.
+            text_model_type = original_config.model.params.cond_stage_config.target.split(".")[-1]
+            tokenizer_type = "CLIPTokenizer"
+            if text_model_type == "FrozenOpenCLIPEmbedder":
+                text_model = convert_open_clip_checkpoint(checkpoint)
+                tokenizer = CLIPTokenizer.from_pretrained("stabilityai/stable-diffusion-2", subfolder="tokenizer")
+            elif text_model_type == "FrozenCLIPEmbedder":
+                text_model = convert_ldm_clip_checkpoint(checkpoint)
+                tokenizer = CLIPTokenizer.from_pretrained("openai/clip-vit-large-patch14")
+            else:
+                text_config = create_ldm_bert_config(original_config)
+                text_model = convert_ldm_bert_checkpoint(checkpoint, text_config)
+                tokenizer = BertTokenizerFast.from_pretrained("bert-base-uncased")
+                tokenizer_type = "BertTokenizerFast"
+
+            to_save = {"text_encoder": text_model, "tokenizer": tokenizer}
+
+            for name, model in to_save.items():
+                if model is None:
+                    continue
+                print(f"Saving {name}")
+                model.save_pretrained(os.path.join(db_config.pretrained_model_name_or_path, name), safe_serialization=True)
+                del model
+
+            del checkpoint
+
+            if "nonema" in checkpoint_file and extract_ema:
+                ema_checkpoint_file = checkpoint_file.replace("nonema", "ema")
+                if os.path.exists(ema_checkpoint_file):
+                    printi("Extracting secondary checkpoint for EMA weights.")
+                    checkpoint = load_checkpoint(ema_checkpoint_file, map_location)
+                    unet = UNet2DConditionModel(**unet_config)
+
+                    converted_unet_checkpoint, _ = convert_ldm_unet_checkpoint(
+                        checkpoint, unet_config, path=checkpoint_file
+                    )
+
+                    unet.load_state_dict(converted_unet_checkpoint)
+                    unet.save_pretrained(os.path.join(db_config.pretrained_model_name_or_path, "ema_unet"),
+                                        safe_serialization=True)
+                    del unet
+                    db_config.has_ema = has_ema
+
+                    db_config.save()
+
+            try:
+                diff_ver = importlib_metadata.version("diffusers")
+            except:
+                diff_ver = "0.10.2"
+
+            ckpt_config = {
+                "_class_name": "StableDiffusionPipeline",
+                "_diffusers_version": diff_ver,
+                "feature_extractor": [None, None],
+                "requires_safety_checker": None,
+                "safety_checker": [None, None],
+                "scheduler": ["diffusers", scheduler_type],
+                "text_encoder": ["transformers", "CLIPTextModel"],
+                "tokenizer": ["transformers", tokenizer_type],
+                "unet": ["diffusers", "UNet2DConditionModel"],
+                "vae": ["diffusers", "AutoencoderKL"]
+            }
+            if db_config.has_ema:
+                ckpt_config["ema_unet"] = ["diffusers", "UNet2DConditionModel"]
+
+            idx_file = os.path.join(db_config.pretrained_model_name_or_path, "model_index.json")
+            with open(idx_file, "w") as iof:
+                json.dump(ckpt_config, iof, indent=4)
+
+        except Exception as e:
+            print(f"Exception setting up output: {e}")
+            traceback.print_exc()
+        
+
+
+        result_status = f"Checkpoint successfully extracted to {db_config.pretrained_model_name_or_path}"
+
     model_dir = db_config.model_dir
     revision = db_config.revision
     src = db_config.src
+    shared_src_path = db_config.shared_diffusers_path
     required_dirs = ["unet", "vae", "text_encoder", "scheduler", "tokenizer"]
-    if original_config_file is not None and os.path.exists(original_config_file):
-        shutil.copy(original_config_file, db_config.model_dir)
-        basename = os.path.basename(original_config_file)
-        new_ex_path = os.path.join(db_config.model_dir, basename)
-        new_name = os.path.join(db_config.model_dir, f"{db_config.model_name}.yaml")
-        if os.path.exists(new_name):
-            os.remove(new_name)
-        os.rename(new_ex_path, new_name)
+
+    if shared_src_name == LORA_SHARED_SRC_CREATE:
+        copy_config_file(original_config_file,
+                         os.path.dirname(db_config.shared_diffusers_path),
+                         shared_src)
+        original_config_file = os.path.join(shared.models_path, "diffusers", shared_src, ".yaml")
+        db_config.pretrained_model_name_or_path = ""
+    
+    copy_config_file(original_config_file, db_config.model_dir, db_config.model_name)
 
     for req_dir in required_dirs:
-        full_path = os.path.join(db_config.pretrained_model_name_or_path, req_dir)
+        full_path = os.path.join(db_config.get_pretrained_model_name_or_path(), req_dir)
         if not os.path.exists(full_path):
             result_status = f"Missing model directory, removing model: {full_path}"
             shutil.rmtree(db_config.model_dir, ignore_errors=False, onerror=None)
@@ -1339,6 +1392,7 @@ def extract_checkpoint(new_model_name: str, checkpoint_file: str, from_hub=False
         revision, \
         epoch, \
         src, \
+        shared_src_path, \
         "True" if has_ema else "False", \
         "True" if v2 else "False", \
         db_config.resolution, \

--- a/dreambooth/train_dreambooth.py
+++ b/dreambooth/train_dreambooth.py
@@ -242,7 +242,7 @@ def main(class_gen_method: str = "Native Diffusers") -> TrainResult:
             vae_path = (
                 args.pretrained_vae_name_or_path
                 if args.pretrained_vae_name_or_path
-                else args.pretrained_model_name_or_path
+                else args.get_pretrained_model_name_or_path()
             )
             disable_safe_unpickle()
             new_vae = AutoencoderKL.from_pretrained(
@@ -258,19 +258,19 @@ def main(class_gen_method: str = "Native Diffusers") -> TrainResult:
         disable_safe_unpickle()
         # Load the tokenizer
         tokenizer = AutoTokenizer.from_pretrained(
-            os.path.join(args.pretrained_model_name_or_path, "tokenizer"),
+            os.path.join(args.get_pretrained_model_name_or_path(), "tokenizer"),
             revision=args.revision,
             use_fast=False,
         )
 
         # import correct text encoder class
         text_encoder_cls = import_model_class_from_model_name_or_path(
-            args.pretrained_model_name_or_path, args.revision
+            args.get_pretrained_model_name_or_path(), args.revision
         )
 
         # Load models and create wrapper for stable diffusion
         text_encoder = text_encoder_cls.from_pretrained(
-            args.pretrained_model_name_or_path,
+            args.get_pretrained_model_name_or_path(),
             subfolder="text_encoder",
             revision=args.revision,
             torch_dtype=torch.float32,
@@ -280,7 +280,7 @@ def main(class_gen_method: str = "Native Diffusers") -> TrainResult:
         printm("Created vae")
 
         unet = UNet2DConditionModel.from_pretrained(
-            args.pretrained_model_name_or_path,
+            args.get_pretrained_model_name_or_path(),
             subfolder="unet",
             revision=args.revision,
             torch_dtype=torch.float32,
@@ -350,13 +350,13 @@ def main(class_gen_method: str = "Native Diffusers") -> TrainResult:
         if args.use_ema:
             if os.path.exists(
                     os.path.join(
-                        args.pretrained_model_name_or_path,
+                        args.get_pretrained_model_name_or_path(),
                         "ema_unet",
                         "diffusion_pytorch_model.safetensors",
                     )
             ):
                 ema_unet = UNet2DConditionModel.from_pretrained(
-                    args.pretrained_model_name_or_path,
+                    args.get_pretrained_model_name_or_path(),
                     subfolder="ema_unet",
                     revision=args.revision,
                     torch_dtype=torch.float32,
@@ -802,7 +802,7 @@ def main(class_gen_method: str = "Native Diffusers") -> TrainResult:
                 printm("Creating pipeline.")
 
                 s_pipeline = DiffusionPipeline.from_pretrained(
-                    args.pretrained_model_name_or_path,
+                    args.get_pretrained_model_name_or_path(),
                     unet=accelerator.unwrap_model(unet, keep_fp32_wrapper=True),
                     text_encoder=accelerator.unwrap_model(
                         text_encoder, keep_fp32_wrapper=True
@@ -860,7 +860,7 @@ def main(class_gen_method: str = "Native Diffusers") -> TrainResult:
                                 if ema_model is not None:
                                     ema_model.save_pretrained(
                                         os.path.join(
-                                            args.pretrained_model_name_or_path,
+                                            args.get_pretrained_model_name_or_path(),
                                             "ema_unet",
                                         ),
                                         safe_serialization=True,

--- a/dreambooth/train_imagic.py
+++ b/dreambooth/train_imagic.py
@@ -164,14 +164,14 @@ def train_imagic(args: DreamboothConfig):
         logging_dir=logging_dir,
     )
 
-    tokenizer = CLIPTokenizer.from_pretrained(args.pretrained_model_name_or_path, subfolder="tokenizer",
+    tokenizer = CLIPTokenizer.from_pretrained(args.get_pretrained_model_name_or_path(), subfolder="tokenizer",
                                               use_auth_token=False)
 
     # Load models and create wrapper for stable diffusion
-    text_encoder = CLIPTextModel.from_pretrained(args.pretrained_model_name_or_path, subfolder="text_encoder",
+    text_encoder = CLIPTextModel.from_pretrained(args.get_pretrained_model_name_or_path(), subfolder="text_encoder",
                                                  use_auth_token=False)
-    vae = AutoencoderKL.from_pretrained(args.pretrained_model_name_or_path, subfolder="vae", use_auth_token=True)
-    unet = UNet2DConditionModel.from_pretrained(args.pretrained_model_name_or_path, subfolder="unet",
+    vae = AutoencoderKL.from_pretrained(args.get_pretrained_model_name_or_path(), subfolder="vae", use_auth_token=True)
+    unet = UNet2DConditionModel.from_pretrained(args.get_pretrained_model_name_or_path(), subfolder="unet",
                                                 use_auth_token=False)
 
     if args.gradient_checkpointing:

--- a/dreambooth/ui_functions.py
+++ b/dreambooth/ui_functions.py
@@ -41,6 +41,7 @@ from dreambooth.utils.model_utils import (
     get_lora_models,
     get_checkpoint_match,
     get_model_snapshots,
+    LORA_SHARED_SRC_CREATE,
 )
 from dreambooth.utils.utils import printm, cleanup
 from helpers.image_builder import ImageBuilder
@@ -624,6 +625,7 @@ def load_model_params(model_name):
     db_v2: If the model requires a v2 config/compilation
     db_has_ema: Was the model extracted with EMA weights
     db_src: The source checkpoint that weights were extracted from or hub URL
+    db_shared_diffusers_path: 
     db_scheduler: Scheduler used for this model
     db_model_snapshots: A gradio dropdown containing the available snapshots for the model
     db_outcome: The result of loading model params
@@ -650,6 +652,7 @@ def load_model_params(model_name):
             "True" if config.v2 else "False",
             "True" if config.has_ema else "False",
             config.src,
+            config.shared_diffusers_path,
             db_model_snapshots,
             db_lora_models,
             msg,
@@ -684,7 +687,7 @@ def start_training(model_dir: str, class_gen_method: str = "Native Diffusers"):
             msg = "Using xformers, please set mixed precision to 'fp16' or 'bf16' to continue."
     if not len(config.concepts()):
         msg = "Please configure some concepts."
-    if not os.path.exists(config.pretrained_model_name_or_path):
+    if not os.path.exists(config.get_pretrained_model_name_or_path()):
         msg = "Invalid training data directory."
     if config.pretrained_vae_name_or_path:
         if not os.path.exists(config.pretrained_vae_name_or_path):
@@ -926,6 +929,7 @@ def start_crop(
 def create_model(
         new_model_name: str,
         ckpt_path: str,
+        shared_src: str,
         from_hub=False,
         new_model_url="",
         new_model_token="",
@@ -949,24 +953,25 @@ def create_model(
         if sh is not None:
             sh.end(desc=err_msg)
 
-        return "", "", 0, 0, "", "", "", "", res, "", err_msg
+        return "", "", "", 0, 0, "", "", "", "", res, "", err_msg
 
     new_model_name = sanitize_name(new_model_name)
 
-    if not from_hub:
+    if not from_hub and (shared_src == "" or shared_src == LORA_SHARED_SRC_CREATE):
         checkpoint_info = get_checkpoint_match(ckpt_path)
         if checkpoint_info is None or not os.path.exists(checkpoint_info.filename):
             err_msg = "Unable to find checkpoint file!"
             print(err_msg)
             if sh is not None:
                 sh.end(desc=err_msg)
-            return "", "", 0, 0, "", "", "", "", res, "", err_msg
+            return "", "", "", 0, 0, "", "", "", "", res, "", err_msg
         ckpt_path = checkpoint_info.filename
 
     unload_system_models()
     result = extract_checkpoint(
         new_model_name,
         ckpt_path,
+        shared_src,
         from_hub,
         new_model_url,
         new_model_token,

--- a/dreambooth/utils/model_utils.py
+++ b/dreambooth/utils/model_utils.py
@@ -20,6 +20,7 @@ checkpoints_loaded = collections.OrderedDict()
 model_dir = "Stable-diffusion"
 model_path = os.path.abspath(os.path.join(shared.models_path, model_dir))
 
+LORA_SHARED_SRC_CREATE = " <create new>"
 
 def model_hash(filename):
     """old hash that only looks at a small part of the file and is prone to collisions"""
@@ -113,6 +114,16 @@ os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'
 def get_db_models():
     output = [""]
     out_dir = shared.dreambooth_models_path
+    if os.path.exists(out_dir):
+        for item in os.listdir(out_dir):
+            if os.path.isdir(os.path.join(out_dir, item)):
+                output.append(item)
+    return output
+
+
+def get_shared_models():
+    output = ["", LORA_SHARED_SRC_CREATE]
+    out_dir = os.path.join(shared.models_path, "diffusers")
     if os.path.exists(out_dir):
         for item in os.listdir(out_dir):
             if os.path.isdir(os.path.join(out_dir, item)):

--- a/helpers/image_builder.py
+++ b/helpers/image_builder.py
@@ -75,17 +75,17 @@ class ImageBuilder:
                     print(msg)
             torch_dtype = torch.float16 if shared.device.type == "cuda" else torch.float32
             disable_safe_unpickle()
-            unet_path = os.path.join(config.pretrained_model_name_or_path, "unet")
+            unet_path = os.path.join(config.get_pretrained_model_name_or_path(), "unet")
             if config.infer_ema:
-                ema_path = os.path.join(config.pretrained_model_name_or_path, "ema_unet",
+                ema_path = os.path.join(config.get_pretrained_model_name_or_path(), "ema_unet",
                                         "diffusion_pytorch_model.safetensors")
                 if os.path.isfile(ema_path):
-                    unet_path = os.path.join(config.pretrained_model_name_or_path, "ema_unet")
+                    unet_path = os.path.join(config.get_pretrained_model_name_or_path(), "ema_unet")
 
             self.image_pipe = DiffusionPipeline.from_pretrained(
-                config.pretrained_model_name_or_path,
+                config.get_pretrained_model_name_or_path(),
                 vae=AutoencoderKL.from_pretrained(
-                    config.pretrained_vae_name_or_path or config.pretrained_model_name_or_path,
+                    config.pretrained_vae_name_or_path or config.get_pretrained_model_name_or_path(),
                     subfolder=None if config.pretrained_vae_name_or_path else "vae",
                     revision=config.revision,
                     torch_dtype=torch_dtype

--- a/index.html
+++ b/index.html
@@ -79,6 +79,13 @@
                                                 <label class="form-check-label" for="db_512_model">512x Model</label>
                                             </div>
                                         </div>
+                                        <div class="col-6">
+                                            <div class="form-check">
+                                                <input type="checkbox" class="form-check-input newModelParam" id="db_use_shared_src" data-key="use_shared_src"
+                                                       checked>
+                                                <label class="form-check-label" for="db_use_shared_src">Experimental Shared Src</label>
+                                            </div>
+                                        </div>
                                     </div>
                                     <div class="row">
                                         <div class="col-12">
@@ -97,6 +104,14 @@
                                                      data-model_type="diffusers"
                                                      data-label="Source Checkpoint"
                                                      data-key="new_model_src"></div>
+                                            </div>
+                                            <div class="form-group" id="shared_row">
+                                                <div class="sharedModelSelect"
+                                                     id="new_model_shared_src"
+                                                     data-add_class="newModelParam"
+                                                     data-model_type="diffusers"
+                                                     data-label="EXPERIMENTAL: LoRA Shared Diffusers Source"
+                                                     data-key="new_model_shared_src"></div>
                                             </div>
                                         </div>
                                     </div>

--- a/javascript/dreambooth.js
+++ b/javascript/dreambooth.js
@@ -285,7 +285,7 @@ function db_start_load_params() {
 // Create new checkpoint
 function db_start_create() {
     clear_loaded();
-    return db_start(8, false, true, arguments);
+    return db_start(9, false, true, arguments);
 }
 
 // Train!

--- a/js/module_dreambooth.js
+++ b/js/module_dreambooth.js
@@ -41,6 +41,14 @@ document.addEventListener("DOMContentLoaded", function () {
        }
     });
 
+    $("#db_use_shared_src").change(function(){
+        if ($(this).is(":checked")) {
+            $("#shared_row").show();
+        } else {
+            $("#shared_row").hide();
+        }
+     });
+
     // Register the module with the UI. Icon is from boxicons by default.
     registerModule("Dreambooth", "moduleDreambooth", "cloud", false);
 

--- a/module_dreambooth.py
+++ b/module_dreambooth.py
@@ -34,6 +34,7 @@ class DreamboothModule(BaseModule):
         self.logger.debug(f"Create model called: {data}")
         model_name = data["new_model_name"] if "new_model_name" in data else None
         src = data["new_model_src"]["path"]
+        shared_src = data["new_model_shared_src"]["path"]
         from_hub = data["create_from_hub"] if "create_from_hub" in data else False
         self.logger.debug(f"SRC - {src} and {from_hub}")
         if src and not from_hub:
@@ -43,6 +44,7 @@ class DreamboothModule(BaseModule):
             loop.create_task(extract_checkpoint(
                 model_name,
                 src,
+                shared_src,
                 True,
                 data["new_model_url"],
                 data["new_model_token"],

--- a/scripts/api.py
+++ b/scripts/api.py
@@ -426,6 +426,7 @@ def dreambooth_api(_, app: FastAPI):
             new_model_name: str = Query(description="The name of the model to create.", ),
             new_model_src: str = Query(description="The source checkpoint to extract to create this model.", ),
             new_model_scheduler: str = Query("ddim", description="The scheduler to use. V2+ models ignore this.", ),
+            new_model_shared_src: str = Query(description="The shared diffusers source to use for this differs model.", ),
             create_from_hub: bool = Query(False, description="Create this model from the hub", ),
             new_model_url: str = Query(None,
                                        description="The hub URL to use for this model. Must contain diffusers model.", ),
@@ -435,7 +436,7 @@ def dreambooth_api(_, app: FastAPI):
                                          description="Un-freeze the model.", ),
             new_model_token: str = Query(None, description="Your huggingface hub token.", ),
             new_model_extract_ema: bool = Query(False, description="Whether to extract EMA weights if present.", ),
-            api_key: str = Query("", description="If an API key is set, this must be present.", ),
+            api_key: str = Query("", description="If an API key is set, this must be present.", ),  
     ):
         """
         Create a new Dreambooth model.

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -39,6 +39,7 @@ from dreambooth.utils.model_utils import (
     get_db_models,
     get_sorted_lora_models,
     get_model_snapshots,
+    get_shared_models,
 )
 from dreambooth.utils.utils import (
     list_attention,
@@ -310,6 +311,9 @@ def on_ui_tabs():
                         with gr.Row():
                             gr.HTML(value="Source Checkpoint:")
                             db_src = gr.HTML()
+                        with gr.Row():
+                            gr.HTML(value="Experimental Shared Source:")
+                            db_shared_diffusers_path = gr.HTML()
                     with gr.Tab("Create"):
                         with gr.Column():
                             db_create_model = gr.Button(
@@ -321,6 +325,9 @@ def on_ui_tabs():
                                 label="Create From Hub", value=False
                             )
                             db_512_model = gr.Checkbox(label="512x Model", value=True)
+                            db_use_shared_src = gr.Checkbox(
+                                label="Experimental Shared Src", value=False
+                            )
                         with gr.Column(visible=False) as hub_row:
                             db_new_model_url = gr.Textbox(
                                 label="Model Path",
@@ -340,6 +347,19 @@ def on_ui_tabs():
                                     get_sd_models,
                                     lambda: {"choices": sorted(get_sd_models())},
                                     "refresh_sd_models",
+                                )
+                        with gr.Column(visible=False) as shared_row:
+                            with gr.Row():
+                                db_new_model_shared_src = gr.Dropdown(
+                                    label="EXPERIMENTAL: LoRA Shared Diffusers Source",
+                                    choices=sorted(get_shared_models()),
+                                    value=""
+                                )
+                                create_refresh_button(
+                                    db_new_model_shared_src,
+                                    get_shared_models,
+                                    lambda: {"choices": sorted(get_shared_models())},
+                                    "refresh_shared_models",
                                 )
                         db_new_model_extract_ema = gr.Checkbox(
                             label="Extract EMA Weights", value=False
@@ -1259,6 +1279,7 @@ def on_ui_tabs():
             db_scheduler,
             db_split_loss,
             db_strict_tokens,
+            db_shared_diffusers_path,
             db_shuffle_tags,
             db_snapshot,
             db_src,
@@ -1272,6 +1293,7 @@ def on_ui_tabs():
             db_use_ema,
             db_use_lora,
             db_use_lora_extended,
+            db_use_shared_src,
             db_use_subdir,
             c1_class_data_dir,
             c1_class_guidance_scale,
@@ -1349,6 +1371,7 @@ def on_ui_tabs():
             db_model_path,
             db_revision,
             db_src,
+            db_shared_diffusers_path,
         ]
 
         # Populate by the below method and handed out to other elements
@@ -1390,6 +1413,15 @@ def on_ui_tabs():
             fn=toggle_new_rows,
             inputs=[db_create_from_hub],
             outputs=[hub_row, local_row],
+        )
+
+        def toggle_shared_row(shared_row):
+            return gr.update(visible=shared_row),  gr.update(value="")
+
+        db_use_shared_src.change(
+            fn=toggle_shared_row,
+            inputs=[db_use_shared_src],
+            outputs=[shared_row, db_new_model_shared_src],
         )
 
         db_prior_loss_scale.change(
@@ -1497,6 +1529,7 @@ def on_ui_tabs():
                 db_v2,
                 db_has_ema,
                 db_src,
+                db_shared_diffusers_path,
                 db_snapshot,
                 db_lora_model_name,
                 db_status,
@@ -1622,6 +1655,7 @@ def on_ui_tabs():
             inputs=[
                 db_new_model_name,
                 db_new_model_src,
+                db_new_model_shared_src,
                 db_create_from_hub,
                 db_new_model_url,
                 db_new_model_token,
@@ -1635,6 +1669,7 @@ def on_ui_tabs():
                 db_revision,
                 db_epochs,
                 db_src,
+                db_shared_diffusers_path,
                 db_has_ema,
                 db_v2,
                 db_resolution,


### PR DESCRIPTION
## Describe your changes

Since the LoRA training does not mutate the base model, there is no reason to be copying 4GB of models every time we train. In this change, we add a new checkout to the Create UI which exposes a new AI to allow using a shared source diffusers model.

I have tested a bunch of training mostly v1.5 models, but I at least tried creating models on 2.1. I have not tried hub models, they might not work.

I probably need to write some documentation for this if it seems useful. Maybe I should move this into a new branch and have people try it.

## Checklist before requesting a review
- [x] This is based on the /dev branch (Or a fork of it)
- [x] This was created or at least validated using a proper IDE
- [x] I have tested this code and validated any modified functions
- [ ] I have added the appropriate documentation and hint strings if adding or changing a user-facing feature
