### PR TITLE
Update train_dreambooth.py

### DIFF
--- a/dreambooth/train_dreambooth.py
+++ b/dreambooth/train_dreambooth.py
@@ -838,8 +838,9 @@ def main(class_gen_method: str = "Native Diffusers") -> TrainResult:
                 
                 # Save random states so sample generation doesn't impact training.
                 torch_rng_state = torch.get_rng_state()
-                cuda_gpu_rng_state = torch.cuda.get_rng_state(device="cuda")
-                cuda_cpu_rng_state = torch.cuda.get_rng_state(device="cpu")
+                if not shared.force_cpu:
+                    cuda_gpu_rng_state = torch.cuda.get_rng_state(device="cuda")
+                    cuda_cpu_rng_state = torch.cuda.get_rng_state(device="cpu")
 
                 optim_to(profiler, optimizer)
                 
@@ -1101,8 +1102,9 @@ def main(class_gen_method: str = "Native Diffusers") -> TrainResult:
 
                 # Restore all random states to avoid having sampling impact training.
                 torch.set_rng_state(torch_rng_state)
-                torch.cuda.set_rng_state(cuda_cpu_rng_state, device="cpu")
-                torch.cuda.set_rng_state(cuda_gpu_rng_state, device="cuda")
+                if not shared.force_cpu:
+                    torch.cuda.set_rng_state(cuda_cpu_rng_state, device="cpu")
+                    torch.cuda.set_rng_state(cuda_gpu_rng_state, device="cuda")
 
                 cleanup()
                 printm("Completed saving weights.")


### PR DESCRIPTION
Save/Restore cuda random states only if not training with CPU.

## Describe your changes
Even if you enable "--force-cpu" flag, the original code will call torch.cuda on line 841
cuda_gpu_rng_state = torch.cuda.get_rng_state(device="cuda")
And it will trigger _lazy_init() -> torch._C._cuda_init() -> "RuntimeError: Found no NVIDIA driver on your system."

## Issue ticket number and link (if applicable)
N/A

## Checklist before requesting a review
- [?] This is based on the /dev branch (Or a fork of it)
- [x] This was created or at least validated using a proper IDE
- [x] I have tested this code and validated any modified functions
- [x] I have added the appropriate documentation and hint strings if adding or changing a user-facing feature
