### PR TITLE
Process Alpha Channel (Transparency) by Flatten it

### DIFF
--- a/dreambooth/utils/image_utils.py
+++ b/dreambooth/utils/image_utils.py
@@ -450,6 +450,11 @@ def open_and_trim(image_path: str, reso: Tuple[int, int], return_pil: bool = Fal
 
     # Convert to RGB if necessary
     if image.mode != "RGB":
+        # If given image has Alpha Channel, flatten it instead of removing A channel
+        if image.mode.endswith("A"):
+            bg = Image.new("RGB", image.size, "white")
+            bg.paste(image, mask=image.split()[3])
+            image = bg
         image = image.convert("RGB")
 
     # Upscale image if necessary


### PR DESCRIPTION
## Describe your changes
Flatten each channel instead of removing Alpha Channel entirely, this should fix bleeding colour, hollow and bad anti-aliasing.

Tested image format/codec with Transparent:
* PNG
* WebP
* AVIF
* TGA (Game Texture)

About preprocess game texture like DXT5 require `import pyglet` which is not needed at the moment or never, it's better convert DXT instead of reading directly...

## Issue ticket number and link (if applicable)

## Checklist before requesting a review
- [ ] This is based on the /dev branch (Or a fork of it)
- [x] This was created or at least validated using a proper IDE
- [x] I have tested this code and validated any modified functions
- [x] I have added the appropriate documentation and hint strings if adding or changing a user-facing feature

## Results
| Input |  RGB Convert | Flatten |
|-------|---------------|---------|
| ![data pak_000158](https://user-images.githubusercontent.com/1908715/230780389-ad242a63-598e-4ed2-b1ed-a38b6ad32b32.png) | ![Remove Alpha Channel](https://user-images.githubusercontent.com/1908715/230779306-005c34e0-5ffa-4efa-b579-3b019246cd44.png) | ![Flatten](https://user-images.githubusercontent.com/1908715/230779312-7ac8bfdb-e4fa-40fc-866d-db86477107ee.png) |
| ![0003_bs1_YNE1_A001](https://user-images.githubusercontent.com/1908715/230780456-766fe12a-8f1a-49ee-bc8c-3b061a575fca.png) | ![old (4)](https://user-images.githubusercontent.com/1908715/230780515-19dcbc5b-e765-4516-b6b9-049cea168af0.png) | ![0003_bs1_YNE1_A001](https://user-images.githubusercontent.com/1908715/230780539-86c39a1d-99c7-4771-8111-1cd30f6ca35c.png) |

![image](https://user-images.githubusercontent.com/1908715/230780241-3fc4bd2c-9dcd-47d3-b7a7-79d068987d79.png)
![image](https://user-images.githubusercontent.com/1908715/230780346-fc568cdf-4b0f-4f35-a63c-d323e50f44b1.png)

