### PR TITLE
Make Concept List file portable!

### DIFF
--- a/dreambooth/dataclasses/db_config.py
+++ b/dreambooth/dataclasses/db_config.py
@@ -2,7 +2,7 @@ import json
 import os
 import traceback
 from typing import List, Dict
-
+from pathlib import Path
 from pydantic import BaseModel
 
 from dreambooth import shared  # noqa

--- a/dreambooth/dataclasses/db_config.py
+++ b/dreambooth/dataclasses/db_config.py
@@ -323,6 +323,12 @@ def concepts_from_file(concepts_path: str):
     try:
         concepts_data = json.loads(concepts_str)
         for concept_data in concepts_data:
+            concepts_path_dir = Path(concepts_path).parent # Get which folder is JSON file reside
+            instance_data_dir = concept_data.get("instance_data_dir")
+            if not os.path.isabs(instance_data_dir):
+                print(f"Rebuilding portable concepts path: {concepts_path_dir} + {instance_data_dir}")
+                concept_data["instance_data_dir"] = os.path.join(concepts_path_dir, instance_data_dir)
+
             concept = Concept(input_dict=concept_data)
             if concept.is_valid:
                 concepts.append(concept.__dict__)


### PR DESCRIPTION
# Describe your changes
Automatically rebuild path from where folder JSON is reside and `concat` path that defined, allow user share dataset without needing to edit the JSON. No need to use absolute/rooted path on `instance_data_dir`.

## Example
### Given structured dataset like this:
```
E:\dataset\fallenAngel
├───ConceptList.json
├───Anime
│   ├───Aho-Girl
│   │   ├───Akutsu Ruri
│   │   ├───Eimura Akane
│   │   ├───Fuuki Iinchou
│   │   ├───Hanabatake Yoshiko
│   │   └───Sumino Sayaka
│   ⁞
│   ├───Liza Luna
│   ├───Shiina Mahiru
│   └───Yuru Yuri
│       ├───Akaza Akari
│       ├───Funami Yui
│       └───Toshinou Kyouko
⁞
```
### File Explorer
![image](https://user-images.githubusercontent.com/1908715/236105400-4a120989-6953-47e5-b742-48c55ee5bfc5.png)

### JSON Array (mix-match path)
```json
[
	{
		"class_data_dir": "",
		"class_guidance_scale": 12,
		"class_infer_steps": 20,
		"class_negative_prompt": "lowres, bad anatomy, bad hands, text, error, missing fingers, extra digit, fewer digits, cropped, worst quality, low quality, normal quality, jpeg artifacts, signature, watermark, username, blurry, artist name",
		"class_prompt": "1girl, solo, red hair, red eyes, two side up",
		"class_token": "",
		"instance_data_dir": "E:\\dataset\\_FallenAngel\\Anime\\Aho-Girl\\Eimura Akane",
		"instance_prompt": "[filewords]",
		"instance_token": "",
		"is_valid": true,
		"n_save_sample": 1,
		"num_class_images_per": 0,
		"sample_seed": 420420,
		"save_guidance_scale": 12,
		"save_infer_steps": 40,
		"save_sample_negative_prompt": "lowres, bad anatomy, bad hands, text, error, missing fingers, extra digit, fewer digits, cropped, worst quality, low quality, normal quality, jpeg artifacts, signature, watermark, username, blurry, artist name",
		"save_sample_prompt": "masterpiece, best quality, highres, 1girl, [filewords]",
		"save_sample_template": ""
	},
	{
		"class_data_dir": "",
		"class_guidance_scale": 12,
		"class_infer_steps": 20,
		"class_negative_prompt": "lowres, bad anatomy, bad hands, text, error, missing fingers, extra digit, fewer digits, cropped, worst quality, low quality, normal quality, jpeg artifacts, signature, watermark, username, blurry, artist name",
		"class_prompt": "1girl, solo, grey hair, grey eyes, long hair, choker",
		"class_token": "",
		"instance_data_dir": "Anime\\Liza Luna",
		"instance_prompt": "[filewords]",
		"instance_token": "",
		"is_valid": true,
		"n_save_sample": 1,
		"num_class_images_per": 0,
		"sample_seed": 420420,
		"save_guidance_scale": 12,
		"save_infer_steps": 40,
		"save_sample_negative_prompt": "lowres, bad anatomy, bad hands, text, error, missing fingers, extra digit, fewer digits, cropped, worst quality, low quality, normal quality, jpeg artifacts, signature, watermark, username, blurry, artist name",
		"save_sample_prompt": "masterpiece, best quality, highres, 1girl, [filewords]",
		"save_sample_template": ""
	}
]
```

### Console
When `instance_data_dir` is not rooted path, it will concat folder path from `ConceptList.json` and print a message:
![Stable Diffusion A I](https://user-images.githubusercontent.com/1908715/236104578-fa31a910-55f2-4992-91ca-b5944dcc7d2b.png)

## Validation
The `os.path.join()` support `..` path, user can put `*.json` into a folder and `"instance_data_dir": "..\\Anime\\Liza Luna",`

## Coloured Terminal
I plan to use colour text by using ANSI escape sequences, Windows Terminal supported but not on old plain Windows Console (cmd.exe):
```py
print("\033[33mRebuilding portable concepts path:\033[0m " + \
		f"\033[32m{concepts_path_dir}\033[0m " + \
		"\033[31m+\033[0m " + \
		f"\033[32m{instance_data_dir}\033[0m") # Windows Terminal now support ANSI escape sequences
```
I'll leave it here for future reference/update

# Issue ticket number and link (if applicable)
-

# Checklist before requesting a review
- [ ] This is based on the /dev branch (Or a fork of it)
- [x] This was created or at least validated using a proper IDE
- [x] I have tested this code and validated any modified functions
- [x] I have added the appropriate documentation and hint strings if adding or changing a user-facing feature
