### PR TITLE
Quick fix for checkpoint saving error

### DIFF
--- a/helpers/image_builder.py
+++ b/helpers/image_builder.py
@@ -4,6 +4,7 @@ import random
 import traceback
 from typing import List, Union
 
+import tomesd
 import torch
 from PIL import Image
 from accelerate import Accelerator

--- a/helpers/image_builder.py
+++ b/helpers/image_builder.py
@@ -4,7 +4,6 @@ import random
 import traceback
 from typing import List, Union
 
-import tomesd
 import torch
 from PIL import Image
 from accelerate import Accelerator


### PR DESCRIPTION
Attempt to fix
```st
File "...\sd_dreambooth_extension\dreambooth\train_dreambooth.py", line 973, in save_weights
    s_pipeline = DiffusionPipeline.from_pretrained(
  File "...\site-packages\diffusers\pipelines\pipeline_utils.py", line 1039, in from_pretrained
    loaded_sub_model = load_sub_model(
  File "...\site-packages\diffusers\pipelines\pipeline_utils.py", line 445, in load_sub_model
    loaded_sub_model = load_method(os.path.join(cached_folder, name), **loading_kwargs)
  File "...\site-packages\diffusers\models\modeling_utils.py", line 583, in from_pretrained
    raise ValueError(
ValueError: Cannot load <class 'diffusers.models.unet_2d_condition.UNet2DConditionModel'> from ...\AppData\Local\Temp\tmpz5b_v_5g\unet because the following keys are missing: 
 up_blocks.1.resnets.2.conv2.weight, down_blocks.1.resnets.0.conv_shortcut.weight, up_blocks.1.attentions.0.transformer_blocks.0.attn2.to_v.weight, 
...
```
The error recommends:
> Please make sure to pass `low_cpu_mem_usage=False` and `device_map=None` if you want to randomly initialize those weights or else make sure your checkpoint file is correct.

I tried it and it does get rid of the error.