### PR TITLE
Check for xformers before enabling memory efficient attention in samp…

### DIFF
--- a/helpers/image_builder.py
+++ b/helpers/image_builder.py
@@ -10,6 +10,7 @@ from PIL import Image
 from accelerate import Accelerator
 from diffusers import DiffusionPipeline, AutoencoderKL, UNet2DConditionModel
 from diffusers.models.attention_processor import AttnProcessor2_0
+from diffusers.utils.import_utils import is_xformers_available
 
 from dreambooth import shared
 from dreambooth.dataclasses.db_config import DreamboothConfig
@@ -107,7 +108,8 @@ class ImageBuilder:
             self.image_pipe.unet.set_attn_processor(AttnProcessor2_0())
             if os.name != "nt":
                 self.image_pipe.unet = torch.compile(self.image_pipe.unet)
-            self.image_pipe.enable_xformers_memory_efficient_attention()
+            if is_xformers_available():
+                self.image_pipe.enable_xformers_memory_efficient_attention()
             self.image_pipe.vae.enable_slicing()
             tomesd.apply_patch(self.image_pipe, ratio=0.5)
             self.image_pipe.scheduler.config["solver_type"] = "bh2"


### PR DESCRIPTION
…le pipeline

If xformers isn't installed, `enable_xformers_memory_efficient_attention()` raises an exception, which breaks sample generation. This adds a check.

## Checklist before requesting a review
- [+] This is based on the /dev branch (Or a fork of it)
- [+] This was created or at least validated using a proper IDE
- [+] I have tested this code and validated any modified functions
- [N/A] I have added the appropriate documentation and hint strings if adding or changing a user-facing feature
