### PR TITLE
[HOT-FIX] Bump transformers to 4.30.1 to fix BFloat16 error with sample image generation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ lion-pytorch~=0.1.2
 Pillow==9.5.0
 tqdm==4.65.0
 tomesd~=0.1.2
-transformers~=4.29.2  # > 4.26.x causes issues (db extension #1110)
+transformers~=4.30.1  # > 4.26.x causes issues (db extension #1110)
 
 # Tensor
 tensorboard==2.13.0; sys_platform != 'darwin' or platform_machine != 'arm64'


### PR DESCRIPTION
## Describe your changes

Bumped the version of `transformers` in requirements.txt to version `4.30.1` to resolve an issue with sample image generation during training.

## Issue ticket number and link (if applicable)

https://github.com/d8ahazard/sd_dreambooth_extension/issues/1275

## Checklist before requesting a review
- [X] This is based on the /dev branch (Or a fork of it)
- [X] This was created or at least validated using a proper IDE
- [X] I have tested this code and validated any modified functions
- [ ] I have added the appropriate documentation and hint strings if adding or changing a user-facing feature
