### PR TITLE
[HOT-FIX] Fix creating a model via the REST API

### DIFF
--- a/scripts/api.py
+++ b/scripts/api.py
@@ -429,8 +429,8 @@ def dreambooth_api(_, app: FastAPI):
             create_from_hub: bool = Query(False, description="Create this model from the hub", ),
             new_model_url: str = Query(None,
                                        description="The hub URL to use for this model. Must contain diffusers model.", ),
-            is_512: bool = Query(False,
-                                 description="Whether or not the model is 512x resolution.", ),
+            model_type: str = Query("v1x",
+                                 description="Model type (v1x/v2x-512/v2x/sdxl)", ),
             train_unfrozen: bool = Query(True,
                                          description="Un-freeze the model.", ),
             new_model_token: str = Query(None, description="Your huggingface hub token.", ),
@@ -465,7 +465,7 @@ def dreambooth_api(_, app: FastAPI):
                            new_model_token=new_model_token,
                            extract_ema=new_model_extract_ema,
                            train_unfrozen=train_unfrozen,
-                           is_512=is_512)
+                           model_type=model_type)
 
         return JSONResponse(res[-1])
 


### PR DESCRIPTION
## Describe your changes

Model creation via the REST API is no longer working after the recent training changes due to `is_512` being replaced by `model_type`.  This PR resolves the issue so that models can once again be created using the REST API.

## Issue ticket number and link (if applicable)


## Checklist before requesting a review
- [ ] This is based on the /dev branch (Or a fork of it)
- [X] This was created or at least validated using a proper IDE
- [X] I have tested this code and validated any modified functions
- [X] I have added the appropriate documentation and hint strings if adding or changing a user-facing feature
