### PR TITLE
Option to stop train at max steps

### DIFF
--- a/dreambooth/dataclasses/db_config.py
+++ b/dreambooth/dataclasses/db_config.py
@@ -87,6 +87,7 @@ class DreamboothConfig(BaseModel):
     revision: int = 0
     sample_batch_size: int = 1
     sanity_prompt: str = ""
+    sanity_negative_prompt: str = ""
     sanity_seed: int = 420420
     save_ckpt_after: bool = True
     save_ckpt_cancel: bool = False
@@ -108,6 +109,7 @@ class DreamboothConfig(BaseModel):
     snapshot: str = ""
     split_loss: bool = True
     src: str = ""
+    stop_at_steps: bool = False
     stop_text_encoder: float = 1.0
     strict_tokens: bool = False
     dynamic_img_norm: bool = False

--- a/dreambooth/train_dreambooth.py
+++ b/dreambooth/train_dreambooth.py
@@ -712,9 +712,10 @@ def main(class_gen_method: str = "Native Diffusers", user: str = None) -> TrainR
         logger.debug(f"  Batch Size Per Device = {train_batch_size}")
         logger.debug(f"  Gradient Accumulation steps = {gradient_accumulation_steps}")
         logger.debug(f"  Total train batch size (w. parallel, distributed & accumulation) = {total_batch_size}")
-        logger.debug(f"  Text Encoder Epochs: {text_encoder_epochs}")
+        logger.debug(f"  Text Encoder Epochs = {text_encoder_epochs}")
         logger.debug(f"  Total optimization steps = {sched_train_steps}")
         logger.debug(f"  Total training steps = {max_train_steps}")
+        logger.debug(f"  Train until max steps: {args.stop_at_steps}")
         logger.debug(f"  Resuming from checkpoint: {resume_from_checkpoint}")
         logger.debug(f"  First resume epoch: {first_epoch}")
         logger.debug(f"  First resume step: {resume_step}")
@@ -736,7 +737,7 @@ def main(class_gen_method: str = "Native Diffusers", user: str = None) -> TrainR
             nonlocal last_image_save
             save_model_interval = args.save_embedding_every
             save_image_interval = args.save_preview_every
-            save_completed = session_epoch >= max_train_epochs
+            save_completed = global_step >= max_train_steps if args.stop_at_steps else session_epoch >= max_train_epochs
             save_canceled = status.interrupted
             save_image = False
             save_model = False
@@ -1506,7 +1507,7 @@ def main(class_gen_method: str = "Native Diffusers", user: str = None) -> TrainR
             check_save(True)
 
             if args.num_train_epochs > 1:
-                training_complete = session_epoch >= max_train_epochs
+                training_complete = global_step >= max_train_steps if args.stop_at_steps else session_epoch >= max_train_epochs
 
             if training_complete or status.interrupted:
                 logger.debug("  Training complete (step check).")

--- a/javascript/dreambooth.js
+++ b/javascript/dreambooth.js
@@ -426,6 +426,7 @@ let db_titles = {
     "Shuffle Tags": "When enabled, tags after the first ',' in a prompt will be randomly ordered, which can potentially improve training.",
     "Source Checkpoint": "The source checkpoint to extract for training.",
     "Step Ratio of Text Encoder Training": "The number of steps per image (Epoch) to train the text encoder for. Set 0.5 for 50% of the epochs",
+    "Train Until Max Steps": "Training will conclude at the maximum number of steps, determined by a combination of Dataset Size, Batch Size, and Gradient Accumulation Steps, rather than strictly adhering to a fixed maximum epoch count. This approach is effective in preventing overfitting on the Anime dataset.",
     "Dynamic Image Normalization": "Normalizes each image separately by mean and standard deviation in your dataset. Useful to preserve likeness to your images.",
     "Strict Tokens": "Parses instance prompts separated by the following characters [,;.!?], and prevents breaking up tokens when using the tokenizer. Useful if you have prompts separated by a lot of tags.",
     "TENC Gradient Clip Norm": "Prevents overfit by clipping gradient norms. Default value is 0.0. Recommended value for Lora is 1.0",

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -1002,6 +1002,7 @@ def on_ui_tabs():
                     db_disable_class_matching = gr.Checkbox(label="Disable Class Matching")
                     db_disable_logging = gr.Checkbox(label="Disable Logging")
                     db_deterministic = gr.Checkbox(label="Deterministic")
+                    db_stop_at_steps = gr.Checkbox(label="Train Until Max Steps")
                     db_ema_predict = gr.Checkbox(label="Use EMA for prediction")
                     db_lora_use_buggy_requires_grad = gr.Checkbox(label="LoRA use buggy requires grad")
                     db_noise_scheduler = gr.Dropdown(
@@ -1292,6 +1293,7 @@ def on_ui_tabs():
             db_revision,
             db_sample_batch_size,
             db_sanity_prompt,
+            db_sanity_negative_prompt,
             db_sanity_seed,
             db_save_ckpt_after,
             db_save_ckpt_cancel,
@@ -1313,6 +1315,7 @@ def on_ui_tabs():
             db_snapshot,
             db_split_loss,
             db_src,
+            db_stop_at_steps,
             db_stop_text_encoder,
             db_strict_tokens,
             db_dynamic_img_norm,


### PR DESCRIPTION
## Describe your changes
As per title, training will stop when Current Steps has been reached at Max Steps. this should act like old dreambooth where dataset x 100

Tested on 30 dataset, 4x4 (Batch * Grad)
Default: 3200 steps @ 100 epoch
Enabled: 3008 steps @ 94 epoch

![image](https://github.com/d8ahazard/sd_dreambooth_extension/assets/1908715/e4343bc3-7580-45d6-bc0c-69cd9db4f832)

The option is disabled by default, can be loaded via config

![image](https://github.com/d8ahazard/sd_dreambooth_extension/assets/1908715/cb392646-2ec6-475c-915a-8f8b5d390f57)

Show the state of `Train until max steps` in debug:

![image](https://github.com/d8ahazard/sd_dreambooth_extension/assets/1908715/3c6e4df6-6cc8-44b9-a8c9-7ce747c69729)

also fixed `Sanity Sample Negative Prompt` into the config, tired to paste every-time 🤣

## Issue ticket number and link (if applicable)


## Checklist before requesting a review
- [ ] This is based on the /dev branch (Or a fork of it)
- [x] This was created or at least validated using a proper IDE
- [x] I have tested this code and validated any modified functions
- [x] I have added the appropriate documentation and hint strings if adding or changing a user-facing feature
