### PR TITLE
Fix VAE checkpoint export

### DIFF
--- a/dreambooth/diff_to_sd.py
+++ b/dreambooth/diff_to_sd.py
@@ -197,7 +197,7 @@ def convert_vae_state_dict(vae_state_dict):
                 v = v.replace(hf_part, sd_part)
             mapping[k] = v
     new_state_dict = {v: vae_state_dict[k] for k, v in mapping.items()}
-    weights_to_convert = ["q", "k", "v", "proj_out"]
+    weights_to_convert = ["q", "k", "v", "proj_out", "to_q", "to_k", "to_v", "to_out.0"]
     keys_to_rename = {}
     for k, v in new_state_dict.items():
         for weight_name in weights_to_convert:
@@ -211,7 +211,7 @@ def convert_vae_state_dict(vae_state_dict):
     for k, v in keys_to_rename.items():
         if k in new_state_dict:
             print(f"Renaming {k} to {v}")
-            new_state_dict[v] = reshape_weight_for_sd(new_state_dict[k])
+            new_state_dict[v] = new_state_dict[k]
             del new_state_dict[k]
     return new_state_dict
 


### PR DESCRIPTION
reshape_weight_for_sd() was being applied to biases as well as weights.

This is not the most elegant fix, but it is the simplest.

## Describe your changes

Fixes convert_vae_state_dict() to not add extra size-1 dimensions to the biases when renaming to_q -> q etc.

## Issue ticket number and link (if applicable)

https://github.com/d8ahazard/sd_dreambooth_extension/issues/1405
https://github.com/d8ahazard/sd_dreambooth_extension/issues/1407

## Checklist before requesting a review
- [ dev is stale ] This is based on the /dev branch (Or a fork of it)
- [ + ] This was created or at least validated using a proper IDE
- [ + ] I have tested this code and validated any modified functions
- [ N/A ] I have added the appropriate documentation and hint strings if adding or changing a user-facing feature
