### PR TITLE
Ema fp32

### DIFF
--- a/dreambooth/train_dreambooth.py
+++ b/dreambooth/train_dreambooth.py
@@ -494,22 +494,24 @@ def main(class_gen_method: str = "Native Diffusers", user: str = None) -> TrainR
                             "diffusion_pytorch_model.safetensors",
                         )
                 ):
+                    # EMA weights must be kept in fp32 even during mixed-precision training, or floating
+                    # point rounding will force (almost) all updates to 0.
                     ema_unet = UNet2DConditionModel.from_pretrained(
                         args.get_pretrained_model_name_or_path(),
                         subfolder="ema_unet",
                         revision=args.revision,
-                        torch_dtype=weight_dtype,
+                        torch_dtype=torch.float32,
                     )
                     if args.attention == "xformers" and not shared.force_cpu:
                         xformerify(ema_unet, use_lora=args.use_lora)
 
                     ema_model = EMAModel(
-                        ema_unet, device=accelerator.device, dtype=weight_dtype
+                        ema_unet, device=accelerator.device, dtype=torch.float32
                     )
                     del ema_unet
                 else:
                     ema_model = EMAModel(
-                        unet, device=accelerator.device, dtype=weight_dtype
+                        unet, device=accelerator.device, dtype=torch.float32
                     )
 
             # Create shared unet/tenc learning rate variables


### PR DESCRIPTION
## Describe your changes

This patch affects models with a weight_dtype of float16 or bfloat16, and use_ema true.

Due to lack of precision, in fp16/bf16 updates to EMA weights will almost always be rounded to 0, meaning the EMA weights never change.

The solution is to always use float32 for the EMA model.

## Issue ticket number and link (if applicable)


## Checklist before requesting a review
- [ ] This is based on the /dev branch (Or a fork of it)
- [ + ] This was created or at least validated using a proper IDE
- [ + ] I have tested this code and validated any modified functions
- [ N/A ] I have added the appropriate documentation and hint strings if adding or changing a user-facing feature
