### PR TITLE
Skip images which failed to load

### DIFF
--- a/dreambooth/utils/image_utils.py
+++ b/dreambooth/utils/image_utils.py
@@ -135,20 +135,23 @@ def sort_prompts(
                 is_class
             )
 
-        w, h = get_dim(img, max_dim)
-        reso = closest_resolution(w, h, bucket_resos)
-        prompt_list = prompts[reso] if reso in prompts else []
-        pd = PromptData(
-            prompt=prompt,
-            negative_prompt=concept.class_negative_prompt if is_class else None,
-            instance_token=concept.instance_token,
-            class_token=concept.class_token,
-            src_image=img,
-            resolution=reso,
-            concept_index=concept_index
-        )
-        prompt_list.append(pd)
-        prompts[reso] = prompt_list
+        try:
+            w, h = get_dim(img, max_dim)
+            reso = closest_resolution(w, h, bucket_resos)
+            prompt_list = prompts[reso] if reso in prompts else []
+            pd = PromptData(
+                prompt=prompt,
+                negative_prompt=concept.class_negative_prompt if is_class else None,
+                instance_token=concept.instance_token,
+                class_token=concept.class_token,
+                src_image=img,
+                resolution=reso,
+                concept_index=concept_index
+            )
+            prompt_list.append(pd)
+            prompts[reso] = prompt_list
+        except:
+            pass
     return dict(sorted(prompts.items()))
 
 


### PR DESCRIPTION
## Describe your changes

An exception while reading an image (such as PIL.Image.DecompressionBombError) during precache causes the entire training run to fail with an unhelpful error that doesn't even say what file didn't load. Instead, skip images that didn't load.

## Issue ticket number and link (if applicable)


## Checklist before requesting a review
- [ ] This is based on the /dev branch (Or a fork of it)
- [ + ] This was created or at least validated using a proper IDE
- [ + ] I have tested this code and validated any modified functions
- [ N/A ] I have added the appropriate documentation and hint strings if adding or changing a user-facing feature
