### PR TITLE
Add freeze_spectral_norm option

### DIFF
--- a/dreambooth/dataclasses/db_config.py
+++ b/dreambooth/dataclasses/db_config.py
@@ -73,6 +73,7 @@ class DreamboothConfig(BaseModel):
     min_snr_gamma: float = 0.0
     use_dream: bool = False
     dream_detail_preservation: float = 0.5
+    freeze_spectral_norm: bool = False
     mixed_precision: str = "fp16"
     model_dir: str = ""
     model_name: str = ""

--- a/helpers/ema_model.py
+++ b/helpers/ema_model.py
@@ -85,6 +85,15 @@ class EMAModel(object):
         ema_state_dict = {}
         ema_params = self.params
         for key, param in new_model.state_dict().items():
+            if ".parametrizations." in key:
+                if ".parametrizations.weight.original" in key:
+                    # Handle reparametrized parameters
+                    param = new_model.get_submodule(key.replace(".parametrizations.weight.original", "")).weight
+                    key = key.replace(".parametrizations.weight.original", ".weight")
+                else:
+                    # Skip extra values used in reparametrization
+                    continue
+        
             try:
                 ema_param = ema_params[key]
             except KeyError:

--- a/index.html
+++ b/index.html
@@ -309,6 +309,13 @@
                                                      data-label="DREAM detail preservation"></div>
                                             </div>
                                             <div class="form-group">
+                                                <div class="form-check form-switch">
+                                                    <input class="dbInput form-check-input" type="checkbox"
+                                                           id="freeze_spectral_norm" name="freeze_spectral_norm">
+                                                    <label class="form-check-label" for="freeze_spectral_norm">Freeze Spectral Norm</label>
+                                                </div>
+                                            </div>
+                                            <div class="form-group">
                                                 <div class="dbInput db-slider" data-min="75" data-max="300"
                                                      data-step="75" id="max_token_length" data-value="75"
                                                      data-label="Max Token length"></div>

--- a/javascript/dreambooth.js
+++ b/javascript/dreambooth.js
@@ -330,6 +330,7 @@ let db_titles = {
     "Use Concepts List": "Train multiple concepts from a JSON file or string.",
     "Use DREAM": "Enable DREAM (http://arxiv.org/abs/2312.00210). This may provide better results, but trains slower.",
     "DREAM detail preservation": "A factor that influences how DREAM trades off composition versus detail. Low values will improve composition but may result in loss of detail. High values preserve detail but may reduce the overall effect of DREAM.",
+	"Freeze Spectral Norm": "Prevents the overall magnitude of weights from changing during training. This helps stabilize training at high learning rates. Not compatible with LORA.",
     "Use EMA": "Enabling this will provide better results and editability, but cost more VRAM.",
     "Use EMA for prediction": "",
     "Use EMA Weights for Inference": "Enabling this will save the EMA unet weights as the 'normal' model weights and ignore the regular unet weights.",

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -652,6 +652,9 @@ def on_ui_tabs():
                             value=0.5,
                             visible=True,
                         )
+                        db_freeze_spectral_norm = gr.Checkbox(
+                            label="Freeze Spectral Norm", value=False
+                        )
                         db_pad_tokens = gr.Checkbox(
                             label="Pad Tokens", value=True
                         )
@@ -1361,6 +1364,7 @@ def on_ui_tabs():
             db_min_snr_gamma,
             db_use_dream,
             db_dream_detail_preservation,
+            db_freeze_spectral_norm,
             db_pad_tokens,
             db_strict_tokens,
             db_max_token_length,
@@ -1496,6 +1500,7 @@ def on_ui_tabs():
             db_min_snr_gamma,
             db_use_dream,
             db_dream_detail_preservation,
+            db_freeze_spectral_norm,
             db_mixed_precision,
             db_model_name,
             db_model_path,

--- a/templates/defaults/defaults.json
+++ b/templates/defaults/defaults.json
@@ -161,6 +161,9 @@
     "max": 1,
     "step": 0.01
   },
+  "freeze_spectral_norm": {
+    "value": false
+  },
   "max_token_length": {
     "value": 75,
     "min": 75,

--- a/templates/defaults/dreambooth_model_config.json
+++ b/templates/defaults/dreambooth_model_config.json
@@ -40,6 +40,7 @@
     "min_snr_gamma": 0.0,
     "use_dream": false,
     "dream_detail_preservation": 0.5,
+    "freeze_spectral_norm": false,
     "mixed_precision": "fp16",
     "noise_scheduler": "DDPM",
     "num_train_epochs": 200,

--- a/templates/locales/titles_en.json
+++ b/templates/locales/titles_en.json
@@ -198,6 +198,11 @@
     "title": "Select how much detail DREAM preserves.",
     "description": "A factor that influences how DREAM trades off composition versus detail. Low values will improve composition but may result in loss of detail. High values preserve detail but may reduce the overall effect of DREAM."
   },
+  "freeze_spectral_norm": {
+    "label": "Freeze Spectral Norm",
+    "title": "Freeze spectral norm of the model weights.",
+    "description": "Prevents the overall magnitude of weights from changing during training. This helps stabilize training at high learning rates. Not compatible with LORA."
+  },
   "train_unet": {
     "label": "Train UNET",
     "title": "Train UNET as an additional module.",


### PR DESCRIPTION
## Describe your changes

See https://arxiv.org/abs/2303.06296

This adds an option to reparametrize the model weights using the spectral norm so that the overall norm of each weight can't change. This helps to stabilize training at high learning rates.

## Issue ticket number and link (if applicable)


## Checklist before requesting a review
- [ ] This is based on the /dev branch (Or a fork of it)
- [+] This was created or at least validated using a proper IDE
- [+] I have tested this code and validated any modified functions
- [+] I have added the appropriate documentation and hint strings if adding or changing a user-facing feature
