### PR TITLE
Speed up preprocessing

### DIFF
--- a/dreambooth/dataset/class_dataset.py
+++ b/dreambooth/dataset/class_dataset.py
@@ -16,7 +16,7 @@ from helpers.mytqdm import mytqdm
 class ClassDataset(Dataset):
     """A simple dataset to prepare the prompts to generate class images on multiple GPUs."""
 
-    def __init__(self, concepts: [Concept], model_dir: str, max_width: int, shuffle: bool, disable_class_matching: bool, pbar: mytqdm = None):
+    def __init__(self, concepts: [Concept], model_dir: str, max_width: int, shuffle: bool, disable_class_matching: bool, pbar: mytqdm = None, data_cache = None):
         # Existing training image data
         self.instance_prompts = []
         # Existing class image data
@@ -67,7 +67,7 @@ class ClassDataset(Dataset):
                 class_dir = os.path.join(model_dir, f"classifiers_{concept_idx}")
 
             # ===== Instance =====
-            instance_prompt_buckets = sort_prompts(concept, text_getter, instance_dir, instance_images[concept_idx], bucket_resos, concept_idx, False, pbar)
+            instance_prompt_buckets = sort_prompts(concept, text_getter, instance_dir, instance_images[concept_idx], bucket_resos, concept_idx, False, pbar, data_cache=data_cache)
             for _, instance_prompt_datas in instance_prompt_buckets.items():
                 # Extend instance prompts by the instance data
                 self.instance_prompts.extend(instance_prompt_datas)
@@ -77,13 +77,13 @@ class ClassDataset(Dataset):
                 continue
 
             if disable_class_matching:
-                class_prompt_buckets = sort_prompts(concept, text_getter, class_dir, class_images[concept_idx], bucket_resos, concept_idx, True, pbar)
+                class_prompt_buckets = sort_prompts(concept, text_getter, class_dir, class_images[concept_idx], bucket_resos, concept_idx, True, pbar, data_cache=data_cache)
                 for class_prompt_datas in class_prompt_buckets.values():
                     self.class_prompts.extend(class_prompt_datas)
                 continue
 
-            required_prompt_buckets = sort_prompts(concept, text_getter, class_dir, instance_images[concept_idx], bucket_resos, concept_idx, True, pbar)
-            existing_prompt_buckets = sort_prompts(concept, text_getter, class_dir, class_images[concept_idx], bucket_resos, concept_idx, True, pbar, True)
+            required_prompt_buckets = sort_prompts(concept, text_getter, class_dir, instance_images[concept_idx], bucket_resos, concept_idx, True, pbar, data_cache=data_cache)
+            existing_prompt_buckets = sort_prompts(concept, text_getter, class_dir, class_images[concept_idx], bucket_resos, concept_idx, True, pbar, True, data_cache=data_cache)
 
             # Iterate over each resolution of images, per concept
             for res, required_prompt_datas in required_prompt_buckets.items():

--- a/dreambooth/dataset/db_dataset.py
+++ b/dreambooth/dataset/db_dataset.py
@@ -103,8 +103,9 @@ class DbDataset(torch.utils.data.Dataset):
         flip_p = 0.5 if hflip else 0.0
         self.image_transforms = self.build_compose(hflip, flip_p)
 
-    def load_cache_file(self):
-        cache_file = os.path.join(self.cache_dir, f"cache_{self.resolution}.safetensors")
+    @staticmethod
+    def load_cache_file(cache_dir, resolution):
+        cache_file = os.path.join(cache_dir, f"cache_{resolution}.safetensors")
         latents_cache = {}
         if os.path.exists(cache_file):
             print("Loading latent cache...")
@@ -328,7 +329,7 @@ class DbDataset(torch.utils.data.Dataset):
 
         return caption, input_ids
 
-    def make_buckets_with_caching(self, vae):
+    def make_buckets_with_caching(self, vae, data_cache = None):
         self.vae = vae
         self.cache_latents = vae is not None
         state = f"Preparing Dataset ({'With Caching' if self.cache_latents else 'Without Caching'})"
@@ -366,7 +367,8 @@ class DbDataset(torch.utils.data.Dataset):
         shared.status.job_no = 0
         total_instances = 0
         total_classes = 0
-        data_cache = self.load_cache_file() if self.cache_latents else {"captions": {}, "latents": {}, "sdxl": {}}
+        if data_cache == None:
+            data_cache = DbDataset.load_cache_file(self.cache_dir, self.resolution) if self.cache_latents else {"captions": {}, "latents": {}, "sdxl": {}}
         has_cache = len(data_cache) > 0
         if self.cache_latents:
             if has_cache:

--- a/dreambooth/train_dreambooth.py
+++ b/dreambooth/train_dreambooth.py
@@ -39,9 +39,11 @@ from torch.utils.data import Dataset
 from transformers import AutoTokenizer
 
 from dreambooth import shared
+from dreambooth.dataclasses.db_config import from_file
 from dreambooth.dataclasses.prompt_data import PromptData
 from dreambooth.dataclasses.train_result import TrainResult
 from dreambooth.dataset.bucket_sampler import BucketSampler
+from dreambooth.dataset.db_dataset import DbDataset
 from dreambooth.dataset.sample_dataset import SampleDataset
 from dreambooth.deis_velocity import get_velocity
 from dreambooth.diff_lora_to_sd_lora import convert_diffusers_to_kohya_lora
@@ -320,8 +322,14 @@ def main(class_gen_method: str = "Native Diffusers", user: str = None) -> TrainR
             stop_text_percentage = 0
         pretrained_path = args.get_pretrained_model_name_or_path()
         logger.debug(f"Pretrained path: {pretrained_path}")
+
+        dataset_args=from_file(args.model_name)
+        data_cache=DbDataset.load_cache_file(os.path.join(args.model_dir, "cache"), dataset_args.resolution) if args.cache_latents else None
+        if data_cache != None:
+            print(f"{len(data_cache['latents'])} cached latents")
+
         count, instance_prompts, class_prompts = generate_classifiers(
-            args, class_gen_method=class_gen_method, accelerator=accelerator, ui=False, pbar=pbar2
+            args, class_gen_method=class_gen_method, accelerator=accelerator, ui=False, pbar=pbar2, data_cache=data_cache
         )
 
         save_token_counts(args, instance_prompts, 10)
@@ -688,7 +696,8 @@ def main(class_gen_method: str = "Native Diffusers", user: str = None) -> TrainR
                 debug=False,
                 model_dir=args.model_dir,
                 max_token_length=args.max_token_length,
-                pbar=pbar2
+                pbar=pbar2,
+                data_cache=data_cache,
             )
             if train_dataset.class_count > 0:
                 with_prior_preservation = True

--- a/dreambooth/utils/gen_utils.py
+++ b/dreambooth/utils/gen_utils.py
@@ -35,7 +35,8 @@ def generate_dataset(
         debug=True,
         model_dir="",
         max_token_length=77,
-        pbar=None):
+        pbar=None,
+        data_cache=None):
     if debug:
         logger.debug("Generating dataset.")
     from dreambooth.ui_functions import gr_update
@@ -89,7 +90,7 @@ def generate_dataset(
         model_dir=model_dir,
         pbar=pbar
     )
-    train_dataset.make_buckets_with_caching(vae)
+    train_dataset.make_buckets_with_caching(vae, data_cache)
 
     # train_dataset = train_dataset.pin_memory()
     logger.debug(f"Total dataset length (steps): {len(train_dataset)}")
@@ -101,7 +102,8 @@ def generate_classifiers(
         class_gen_method: str = "Native Diffusers",
         accelerator: Accelerator = None,
         ui=True,
-        pbar: mytqdm = None
+        pbar: mytqdm = None,
+        data_cache = None,
 ):
     """
 
@@ -122,7 +124,7 @@ def generate_classifiers(
     try:
         status.textinfo = "Preparing dataset..."
         prompt_dataset = ClassDataset(
-            args.concepts(), args.model_dir, args.resolution, False, args.disable_class_matching, pbar=pbar
+            args.concepts(), args.model_dir, args.resolution, False, args.disable_class_matching, pbar=pbar, data_cache=data_cache
         )
         instance_prompts = prompt_dataset.instance_prompts
         class_prompts = prompt_dataset.class_prompts

--- a/dreambooth/utils/image_utils.py
+++ b/dreambooth/utils/image_utils.py
@@ -24,8 +24,16 @@ from dreambooth.shared import status
 
 def get_dim(filename, max_res):
     with Image.open(filename) as im:
-        im = rotate_image_straight(im)
         width, height = im.size
+        try:
+            exif: Image.Exif = image.getexif()
+            if exif:
+                orientation_tag = {v: k for k, v in ExifTags.TAGS.items()}['Orientation']
+                orientation = exif.get(orientation_tag)
+                if orientation == 6 or orientation == 8:
+                    (width, height) = (height, width)
+        except:
+            pass
         if width > max_res or height > max_res:
             aspect_ratio = width / height
             if width > height:

--- a/dreambooth/utils/image_utils.py
+++ b/dreambooth/utils/image_utils.py
@@ -26,7 +26,7 @@ def get_dim(filename, max_res):
     with Image.open(filename) as im:
         width, height = im.size
         try:
-            exif: Image.Exif = image.getexif()
+            exif: Image.Exif = im.getexif()
             if exif:
                 orientation_tag = {v: k for k, v in ExifTags.TAGS.items()}['Orientation']
                 orientation = exif.get(orientation_tag)

--- a/dreambooth/utils/image_utils.py
+++ b/dreambooth/utils/image_utils.py
@@ -117,7 +117,8 @@ def sort_prompts(
         concept_index: int,
         is_class: bool,
         pbar: mytqdm,
-        verbatim=False
+        verbatim: bool=False,
+        data_cache=None,
 ) -> Dict[Tuple[int, int], PromptData]:
     prompts = {}
     max_dim = 0
@@ -144,8 +145,12 @@ def sort_prompts(
             )
 
         try:
-            w, h = get_dim(img, max_dim)
-            reso = closest_resolution(w, h, bucket_resos)
+            if data_cache and data_cache["latents"] and img in data_cache["latents"]:
+                shape = data_cache["latents"][img].shape
+                reso = shape[-1] * 8, shape[-2] * 8
+            else:
+                w, h = get_dim(img, max_dim)
+                reso = closest_resolution(w, h, bucket_resos)
             prompt_list = prompts[reso] if reso in prompts else []
             pd = PromptData(
                 prompt=prompt,


### PR DESCRIPTION
## Describe your changes

Pillow (PIL) supports lazy loading of images, where the actual image data is only loaded when needed. Currently `image_utils.get_dim()` loads the image data to handle EXIF rotations. There's no need to do that, we can just swap width and height if necessary. This gives a ~4x speedup in preload when the latents are already cached.

## Issue ticket number and link (if applicable)


## Checklist before requesting a review
- [ ] This is based on the /dev branch (Or a fork of it)
- [+] This was created or at least validated using a proper IDE
- [+] I have tested this code and validated any modified functions
- [N/A] I have added the appropriate documentation and hint strings if adding or changing a user-facing feature
