### PR TITLE
Fix saving EMA model

### DIFF
--- a/dreambooth/train_dreambooth.py
+++ b/dreambooth/train_dreambooth.py
@@ -1301,7 +1301,7 @@ def main(class_gen_method: str = "Native Diffusers", user: str = None) -> TrainR
                                             weights_dir,
                                             "ema_unet",
                                         ),
-                                        safe_serialization=False,
+                                        safe_serialization=True,
                                     )
                                 pbar2.update()
 

--- a/helpers/ema_model.py
+++ b/helpers/ema_model.py
@@ -131,14 +131,7 @@ class EMAModel(object):
         return model
 
     def save_pretrained(self, model_path, safe_serialization=True):
-        model_file = os.path.join(model_path, "diffusion_pytorch_model.safetensors")
-        model_bin = model_file.replace("safetensors", "bin")
         self.model.save_pretrained(model_path, safe_serialization=safe_serialization)
-        if not os.path.exists(model_file):
-            print("Yeah, regular save_pretrained is not working.")
-            safetensors.torch.save_file(self.model.state_dict(), model_file)
-        if os.path.exists(model_bin):
-            os.remove(model_bin)
         model_config_path = os.path.join(model_path, "config.json")
         if not os.path.exists(model_config_path):
             unet_config_path = model_config_path.replace("ema_", "")


### PR DESCRIPTION
## Describe your changes

EMA saving was broken if `ema_unet/diffusion_pytorch_model.safetensors` already existed. This changes `safe_serialization` to `True` and removes the weird workaround in `ema_model.save_pretrained`.

## Issue ticket number and link (if applicable)


## Checklist before requesting a review
- [ ] This is based on the /dev branch (Or a fork of it)
- [x] This was created or at least validated using a proper IDE
- [x] I have tested this code and validated any modified functions
- [x] I have added the appropriate documentation and hint strings if adding or changing a user-facing feature
