### PR TITLE
Pin diffusers due to deprecation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 bitsandbytes>=0.43.0
 accelerate>=0.21.0
 dadaptation>=3.2
-diffusers>=0.25.0
+diffusers>=0.25.0,<0.27.0
 discord-webhook==1.3.0
 fastapi
 gitpython>=3.1.40

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 bitsandbytes>=0.43.0
 accelerate>=0.21.0
 dadaptation>=3.2
-diffusers>=0.25.0,<0.27.0
+diffusers>=0.25.0,<0.26.0
 discord-webhook==1.3.0
 fastapi
 gitpython>=3.1.40


### PR DESCRIPTION
Fixes #1470

## Describe your changes

Pin the version of diffusers to one that is compatible
* _modify_text_encoder is removed in 0.27.0
* There's another deprecation issue in 0.26.0

## Checklist before requesting a review

- ~This is based on the /dev branch (Or a fork of it)~ No, it's based on main, which is a descendant of the dev branch and is what seems to be shipping. I don't see the value in resolving the conflicts to base it on an older commit
- [x] This was created or at least validated using a proper IDE
- [x] I have tested this code and validated any modified functions
- ~I have added the appropriate documentation and hint strings if adding or changing a user-facing feature~